### PR TITLE
Address CVE-2019-10906 in emailservice

### DIFF
--- a/src/emailservice/requirements.txt
+++ b/src/emailservice/requirements.txt
@@ -15,7 +15,7 @@ googleapis-common-protos==1.5.5  # via google-api-core
 grpcio-health-checking==1.12.1
 grpcio==1.16.1
 idna==2.8                 # via requests
-jinja2==2.10
+jinja2==2.10.1
 markupsafe==1.1.0         # via jinja2
 opencensus[stackdriver]==0.1.10
 protobuf==3.6.1           # via google-api-core, googleapis-common-protos, grpcio-health-checking


### PR DESCRIPTION
Upgrade Jinja2 to version 2.10.1

* [CVE-2019-10906](https://nvd.nist.gov/vuln/detail/CVE-2019-10906)
* [GitHub Security Alert](https://github.com/GoogleCloudPlatform/stackdriver-sandbox/network/alert/src/emailservice/requirements.txt/Jinja2/open)

Signed-off-by: Nathen Harvey <nathenharvey@google.com>