### PR TITLE
Address CVE-2019-10906 in loadgenerator

### DIFF
--- a/src/loadgenerator/requirements.txt
+++ b/src/loadgenerator/requirements.txt
@@ -12,7 +12,7 @@ gevent==1.4.0             # via locustio
 greenlet==0.4.15          # via gevent
 idna==2.8                 # via requests
 itsdangerous==1.1.0       # via flask
-jinja2==2.10              # via flask
+jinja2==2.10.1            # via flask
 locustio==0.8.1
 markupsafe==1.1.0         # via jinja2
 msgpack-python==0.5.6     # via locustio


### PR DESCRIPTION
Upgrade Jinja2 to version 2.10.1

* [CVE-2019-10906](https://nvd.nist.gov/vuln/detail/CVE-2019-10906)
* [GitHub Security Alert](https://github.com/GoogleCloudPlatform/stackdriver-sandbox/network/alert/src/loadgenerator/requirements.txt/Jinja2/open)

Signed-off-by: Nathen Harvey <nathenharvey@google.com>