### PR TITLE
added new stackdriver monitoring/logging to gke cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ terraform/terraform.tfstate.backup
 terraform/terraform
 terraform/terraform_0.11.11_linux_amd64.zip
 terraform/terraform.tfstate
+.token

--- a/terraform/03_gke_cluster.tf
+++ b/terraform/03_gke_cluster.tf
@@ -90,6 +90,11 @@ resource "google_container_cluster" "gke" {
     }
   }
 
+  # Specifies the use of "new" Stackdriver logging and monitoring
+  # https://cloud.google.com/kubernetes-engine-monitoring/
+  logging_service = "logging.googleapis.com/kubernetes"
+  monitoring_service = "monitoring.googleapis.com/kubernetes"
+
   # Stores the zone of created gke cluster
   provisioner "local-exec" {
     command = "gcloud config set compute/zone ${element(random_shuffle.zone.result, 0)}"


### PR DESCRIPTION
Added "new" stackdriver monitoring and logging spec to gke cluster, rather than using the legacy feature.