### PR TITLE
Add scopes to cluster

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,8 +78,11 @@ Guidelines](https://opensource.google.com/conduct/).
 ```bash
 gcloud services enable container.googleapis.com
 
-gcloud container clusters create demo --enable-autoupgrade \
-    --enable-autoscaling --min-nodes=3 --max-nodes=10 --num-nodes=5 --zone=us-central1-a
+gcloud container clusters create demo --zone=us-central1-a \
+    --machine-type=n1-standard-2 \
+    --num-nodes=4 \
+    --enable-stackdriver-kubernetes \
+    --scopes https://www.googleapis.com/auth/cloud-platform
 
 kubectl get nodes
 ```

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ cluster: check-env
 	gcloud beta container clusters create ${CLUSTER} \
 		--project=${PROJECT_ID} --zone=${ZONE} \
 		--machine-type=n1-standard-2 --num-nodes=4 \
-		--enable-stackdriver-kubernetes --subnetwork=default \
-		--labels csm=
+		--enable-stackdriver-kubernetes \
+		--scopes https://www.googleapis.com/auth/cloud-platform
 	skaffold run --default-repo=gcr.io/${PROJECT_ID}/sandbox -l skaffold.dev/run-id=${CLUSTER}-${PROJECT_ID}-${ZONE}
 
 deploy: check-env


### PR DESCRIPTION
Our test clusters require the "https://www.googleapis.com/auth/cloud-platform" scope to talk with Trace and Profiler APIs. Add this scope to the Makefile and Contributing guide