### PR TITLE
upgrade terraform version

### DIFF
--- a/terraform/install.sh
+++ b/terraform/install.sh
@@ -60,7 +60,7 @@ getBillingAccount() {
 
 installTerraform() {
   sudo apt-get install unzip
-  wget -q https://releases.hashicorp.com/terraform/0.11.11/terraform_0.11.11_linux_amd64.zip -O ./terraform.zip
+  wget -q https://releases.hashicorp.com/terraform/0.12.29/terraform_0.12.29_linux_amd64.zip -O ./terraform.zip
   unzip -o terraform.zip
   sudo install terraform /usr/local/bin
 }
@@ -139,11 +139,8 @@ displaySuccessMessage() {
 log "Checking Prerequisites..."
 getBillingAccount;
 
-log "Make sure Terraform is installed"
-if ! [ -x "$(command -v terraform)" ]; then
-  log "Terraform is not installed. Trying to install it."
-  installTerraform
-fi
+log "Install current version of Terraform"
+installTerraform
 
 # Make sure we use Application Default Credentials for authentication
 # For that we need to unset GOOGLE_APPLICATION_CREDENTIALS and generate


### PR DESCRIPTION
#WHAT: Update the version of terraform that's installed to be the latest version

#WHY: The current version is slightly too old and doesn't support the dashboard resource

#HOW: Changed which version of terraform we install.

#TESTING: install.sh script still works the same, terraform apply will now work in monitoring directory without manual reinstall of proper version.