### PR TITLE
Telemetry frontend: metrics to stdout, tracing in http handlers, gRPC interceptor

### DIFF
--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.10-alpine as builder
+FROM golang:1.14-alpine as builder
 RUN apk add --no-cache ca-certificates git && \
       wget -qO/go/bin/dep https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64 && \
       chmod +x /go/bin/dep

--- a/src/frontend/Gopkg.lock
+++ b/src/frontend/Gopkg.lock
@@ -24,6 +24,14 @@
   version = "v0.5.0"
 
 [[projects]]
+  digest = "1:34624033bc188a4e41a68c1ba6ca9b2650e8c5f2136c28045b18c9c503a749d1"
+  name = "github.com/DataDog/sketches-go"
+  packages = ["ddsketch"]
+  pruneopts = "UT"
+  revision = "43f19ad77ff73bc865c41f7e391ef4b23b82810a"
+  version = "v0.0.1"
+
+[[projects]]
   branch = "master"
   digest = "1:1d8f3cb93c42c5652bb509fde29ecdd1feede9334e355e8bbdc0f9f95b40c254"
   name = "git.apache.org/thrift.git"
@@ -150,6 +158,54 @@
   pruneopts = "UT"
   revision = "b11f239c032624b045c4c2bfd3d1287b4012ce89"
   version = "v0.16.0"
+
+[[projects]]
+  digest = "1:d02187d2b2b2a05d013cd60ab8d1d3e1841bff4f65475572cbc37827f73957ff"
+  name = "go.opentelemetry.io/otel"
+  packages = [
+    "api/correlation",
+    "api/global",
+    "api/global/internal",
+    "api/internal",
+    "api/kv",
+    "api/kv/value",
+    "api/label",
+    "api/metric",
+    "api/metric/registry",
+    "api/oterror",
+    "api/propagation",
+    "api/standard",
+    "api/trace",
+    "api/unit",
+    "exporters/metric/stdout",
+    "instrumentation/grpctrace",
+    "instrumentation/othttp",
+    "internal/metric",
+    "internal/trace/parent",
+    "sdk",
+    "sdk/export/metric",
+    "sdk/export/metric/aggregation",
+    "sdk/export/trace",
+    "sdk/instrumentation",
+    "sdk/internal",
+    "sdk/metric",
+    "sdk/metric/aggregator",
+    "sdk/metric/aggregator/array",
+    "sdk/metric/aggregator/ddsketch",
+    "sdk/metric/aggregator/histogram",
+    "sdk/metric/aggregator/minmaxsumcount",
+    "sdk/metric/aggregator/sum",
+    "sdk/metric/controller/push",
+    "sdk/metric/controller/time",
+    "sdk/metric/processor/basic",
+    "sdk/metric/selector/simple",
+    "sdk/resource",
+    "sdk/trace",
+    "sdk/trace/internal",
+  ]
+  pruneopts = "UT"
+  revision = "58e50e249fe4c57f64e421e300b5d2316ae96811"
+  version = "v0.9.0"
 
 [[projects]]
   branch = "master"
@@ -350,6 +406,16 @@
     "go.opencensus.io/plugin/ochttp/propagation/b3",
     "go.opencensus.io/stats/view",
     "go.opencensus.io/trace",
+    "go.opentelemetry.io/otel/api/global",
+    "go.opentelemetry.io/otel/api/metric",
+    "go.opentelemetry.io/otel/api/standard",
+    "go.opentelemetry.io/otel/api/trace",
+    "go.opentelemetry.io/otel/exporters/metric/stdout",
+    "go.opentelemetry.io/otel/instrumentation/grpctrace",
+    "go.opentelemetry.io/otel/instrumentation/othttp",
+    "go.opentelemetry.io/otel/sdk/metric/controller/push",
+    "go.opentelemetry.io/otel/sdk/resource",
+    "go.opentelemetry.io/otel/sdk/trace",
     "golang.org/x/net/context",
     "google.golang.org/grpc",
   ]

--- a/src/frontend/Gopkg.lock
+++ b/src/frontend/Gopkg.lock
@@ -33,15 +33,6 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:1d8f3cb93c42c5652bb509fde29ecdd1feede9334e355e8bbdc0f9f95b40c254"
-  name = "git.apache.org/thrift.git"
-  packages = ["lib/go/thrift"]
-  pruneopts = "UT"
-  revision = "6503043bc42ab96da14c25f3aee2bb4add719774"
-  source = "github.com/apache/thrift"
-
-[[projects]]
-  branch = "master"
   digest = "1:6cbe7676244a1429f4c22601f799d377a70449469ef636f91d992d719b559ff3"
   name = "github.com/GoogleCloudPlatform/microservices-demo"
   packages = [
@@ -50,6 +41,14 @@
   ]
   pruneopts = "UT"
   revision = "d944092100696aa4a5974ef5c2e710547a824622"
+
+[[projects]]
+  digest = "1:9fe8532210bb4a51753c8b783bb6ff4bf03da370b2440a05f5686b3b440ce930"
+  name = "github.com/GoogleCloudPlatform/opentelemetry-operations-go"
+  packages = ["exporter/trace"]
+  pruneopts = "UT"
+  revision = "a1393affee9a13ed21974ae1d791da1b3189f4a0"
+  version = "v0.2.1"
 
 [[projects]]
   digest = "1:72856926f8208767b837bf51e3373f49139f61889b67dc7fd3c2a0fd711e3f7a"
@@ -137,7 +136,7 @@
   version = "v1.2.0"
 
 [[projects]]
-  digest = "1:a5154dfd6b37bef5a3eab759e13296348e639dc8c7604f538368167782b08ccd"
+  digest = "1:1bb914cfb78f68f488a91cd7872d3d06a5f83c5bbacf0296dbef44e120b00a91"
   name = "go.opencensus.io"
   packages = [
     ".",
@@ -160,7 +159,7 @@
   version = "v0.16.0"
 
 [[projects]]
-  digest = "1:d02187d2b2b2a05d013cd60ab8d1d3e1841bff4f65475572cbc37827f73957ff"
+  digest = "1:2f2ba64eb51ae09d5f683c176a5114f3a6d7e8fd9bb3b196c1fbd7cc0ddc2512"
   name = "go.opentelemetry.io/otel"
   packages = [
     "api/correlation",
@@ -199,6 +198,12 @@
     "sdk/metric/controller/time",
     "sdk/metric/processor/basic",
     "sdk/metric/selector/simple",
+    "instrumentation/grpctrace",
+    "internal/trace/parent",
+    "sdk",
+    "sdk/export/trace",
+    "sdk/instrumentation",
+    "sdk/internal",
     "sdk/resource",
     "sdk/trace",
     "sdk/trace/internal",
@@ -396,6 +401,7 @@
     "contrib.go.opencensus.io/exporter/stackdriver",
     "github.com/GoogleCloudPlatform/microservices-demo/src/frontend/genproto",
     "github.com/GoogleCloudPlatform/microservices-demo/src/frontend/money",
+    "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace",
     "github.com/golang/protobuf/proto",
     "github.com/google/uuid",
     "github.com/gorilla/mux",

--- a/src/frontend/Gopkg.toml
+++ b/src/frontend/Gopkg.toml
@@ -58,6 +58,14 @@
   version = "0.16.0"
 
 [[constraint]]
+  name = "go.opentelemetry.io/otel"
+  version = "^0.9.0"
+
+[[constraint]]
+  name = "github.com/GoogleCloudPlatform/opentelemetry-operations-go"
+  version = ">=0.2.0"
+
+[[constraint]]
   branch = "master"
   name = "golang.org/x/net"
 


### PR DESCRIPTION
Partially resolves #181, subtask of #132 

Progress so far:
- [x] Update docker image to be compatible with OpenTelemetry libraries
- [x] Add basic metrics to HTTP handlers
- [x] Add custom metrics (HTTP request count, HTTP errors count, HTTP request latency)
(https://github.com/GoogleCloudPlatform/stackdriver-sandbox/pull/183#issuecomment-664690690).
- [x] Add OTel gRPC interceptors to gRPC connections and the HTTP server
- [x] Export HTTP server traces to Cloud Trace

TODO:
- [ ] Testing script for tracing.
- [ ] Export metrics to Cloud Monitoring (blocked by dependency update in exporter, opened a [PR](https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/73))


**How to test Metrics Manually:** Deploy (e.g. run `make deploy-continuous PROJECT_ID=<projectid>`) and observe what's printed to stdout from frontend service server. It'll look something like this, and obviously respond to requests to hipster shop.

![image](https://user-images.githubusercontent.com/25183001/88724877-11e9ad00-d0e0-11ea-87d8-32bc9870dafd.png)


<details><summary>Sample Output in Pretty JSON</summary>
<p>

```js
{

   "time":"2020-07-28T21:29:30.458881296Z",
   "updates":[

      {

         "name":"http_request_count{instrumentation.name=hipstershop/frontend}",
         "sum":5
      },
      {

         "name":"http.server.request_content_length{instrumentation.name=go.opentelemetry.io/otel/instrumentation/othttp,http.flavor=1.1,http.host=10.60.5.7:8080,http.scheme=http,http.server_name=frontend}",
         "sum":0
      },
      {

         "name":"http.server.request_content_length{instrumentation.name=go.opentelemetry.io/otel/instrumentation/othttp,http.flavor=1.1,http.host=34.83.167.77,http.scheme=http,http.server_name=frontend}",
         "sum":0
      },
      {

         "name":"http.server.duration{instrumentation.name=go.opentelemetry.io/otel/instrumentation/othttp,http.flavor=1.1,http.host=34.83.167.77,http.request_content_length=32,http.scheme=http,http.server_name=frontend}",
         "min":49211,
         "max":49211,
         "sum":49211,
         "count":1,
         "quantiles":[

            {

               "q":0.5,
               "v":49211
            },
            {

               "q":0.9,
               "v":49211
            },
            {

               "q":0.99,
               "v":49211
            }
         ]
      },
      {

         "name":"http.server.response_content_length{instrumentation.name=go.opentelemetry.io/otel/instrumentation/othttp,http.flavor=1.1,http.host=34.83.167.77,http.request_content_length=32,http.scheme=http,http.server_name=frontend}",
         "sum":0
      },
      {

         "name":"http.server.duration{instrumentation.name=go.opentelemetry.io/otel/instrumentation/othttp,http.flavor=1.1,http.host=34.83.167.77,http.scheme=http,http.server_name=frontend}",
         "min":38423,
         "max":118995,
         "sum":157418,
         "count":2,
         "quantiles":[

            {

               "q":0.5,
               "v":118995
            },
            {

               "q":0.9,
               "v":118995
            },
            {

               "q":0.99,
               "v":118995
            }
         ]
      },
      {

         "name":"http_response_errors{instrumentation.name=hipstershop/frontend}",
         "sum":1
      },
      {

         "name":"http.server.response_content_length{instrumentation.name=go.opentelemetry.io/otel/instrumentation/othttp,http.flavor=1.1,http.host=10.60.5.7:8080,http.scheme=http,http.server_name=frontend}",
         "sum":4
      },
      {

         "name":"http.server.duration{instrumentation.name=go.opentelemetry.io/otel/instrumentation/othttp,http.flavor=1.1,http.host=10.60.5.7:8080,http.scheme=http,http.server_name=frontend}",
         "min":178,
         "max":203,
         "sum":381,
         "count":2,
         "quantiles":[

            {

               "q":0.5,
               "v":203
            },
            {

               "q":0.9,
               "v":203
            },
            {

               "q":0.99,
               "v":203
            }
         ]
      },
      {

         "name":"http_request_latency{instrumentation.name=hipstershop/frontend}",
         "min":0,
         "max":119,
         "sum":207,
         "count":5,
         "quantiles":[

            {

               "q":0.5,
               "v":39
            },
            {

               "q":0.9,
               "v":119
            },
            {

               "q":0.99,
               "v":119
            }
         ]
      },
      {

         "name":"http.server.response_content_length{instrumentation.name=go.opentelemetry.io/otel/instrumentation/othttp,http.flavor=1.1,http.host=34.83.167.77,http.scheme=http,http.server_name=frontend}",
         "sum":22279
      },
      {

         "name":"http.server.request_content_length{instrumentation.name=go.opentelemetry.io/otel/instrumentation/othttp,http.flavor=1.1,http.host=34.83.167.77,http.request_content_length=32,http.scheme=http,http.server_name=frontend}",
         "sum":32
      }
   ]
}
```
</p>
</details>



**How to test Tracing Manually**:  Deploy (e.g. run `make deploy-continuous PROJECT_ID=<projectid>`) and then go to GCP Console > Cloud Trace > Trace List and filter using `LABEL:g.co/agent:opentelemetry`. You should see a number of traces with URI `span.frontend-server` with various latencies. 
![image](https://user-images.githubusercontent.com/25183001/88726686-09df3c80-d0e3-11ea-89ba-b059e6b3bc0c.png)

Choose one with a higher latency (i.e. higher on the y-axis) and you'll see something interesting like this:
![image](https://user-images.githubusercontent.com/25183001/88724410-4741cb00-d0df-11ea-9fa6-f60c7e4c5870.png)
