### PR TITLE
frontend SLO and alerting policies

### DIFF
--- a/terraform/monitoring/03_service_slo.tf
+++ b/terraform/monitoring/03_service_slo.tf
@@ -1,0 +1,103 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Create a custom service that we attach our SLOs to
+# Using a custom service here allows us to add on additional SLOs and 
+# alerting policies on things such as custom metrics.
+#
+# There is the option to use an Istio service since Istio automatically detects and creates 
+# services for us. This example uses a custom service to demonstrate Terraform support for 
+# creating custom services with attached SLOs and alerting policies.
+resource "google_monitoring_custom_service" "frontend" {
+  service_id = "frontend-srv"
+  display_name = "Frontend Service"
+}
+
+# Create an SLO for availablity for the frontend service.
+# The SLO is defined as following: 
+#   80% of all non-4XX requests within the past 30 day windowed period
+#   return with 200 OK status
+resource "google_monitoring_slo" "frontend_availability_slo" {
+  service = google_monitoring_custom_service.frontend.service_id
+  slo_id = "availability-slo"
+  display_name = "Availability SLO with request base SLI (good total ratio)"
+
+  # The goal sets our 80% objective with a 30 day rolling window period
+  # NOTE: An 80% SLO is not meant to be exemplary of best practice, but it is used for educational
+  # purposes. The value can be modified to see its impacts on error budget.
+  goal = 0.8
+  rolling_period_days = 30
+
+  request_based_sli {
+    good_total_ratio {
+
+      # The "good" service is the number of 200 OK responses
+      good_service_filter = join(" AND ", [
+        "metric.type=\"istio.io/service/server/request_count\"",
+        "resource.type=\"k8s_container\"",
+        "resource.label.\"cluster_name\"=\"stackdriver-sandbox\"",
+        "metadata.user_labels.\"app\"=\"frontend\"",
+        "metric.label.\"response_code\"=\"200\""
+      ])
+
+      # The total is the number of non-4XX responses
+      # We elimiate 4XX responses since they do not accurately represent server-side 
+      # failures and have the possibility of skewing our SLO measurements
+      total_service_filter = join(" AND ", [
+        "metric.type=\"istio.io/service/server/request_count\"",
+        "resource.type=\"k8s_container\"",
+        "resource.label.\"cluster_name\"=\"stackdriver-sandbox\"",
+        "metadata.user_labels.\"app\"=\"frontend\"",
+        join(" OR ", ["metric.label.\"response_code\"<\"400\"",
+          "metric.label.\"response_code\">=\"500\""])
+      ])
+      
+    }
+  }
+}
+
+# Create another SLO on the frontend service this time with respect to latency.
+# Our SLO is defined as following:
+#   80% of requests that return 200 OK responses return in under 500 ms
+resource "google_monitoring_slo" "frontend_latency_slo" {
+  service = google_monitoring_custom_service.frontend.service_id
+  slo_id = "latency-slo"
+  display_name = "Latency SLO with request base SLI (distribution cut)"
+
+  # Again we set our goal of 80% with a 30 day rolling window period.
+  goal = 0.8
+  rolling_period_days = 30
+
+  request_based_sli {
+    distribution_cut {
+
+      # The distribution filter retrieves latencies of requests that returned 200 OK responses
+      distribution_filter = join(" AND ", [
+        "metric.type=\"istio.io/service/server/response_latencies\"",
+        "resource.type=\"k8s_container\"",
+        "resource.label.\"cluster_name\"=\"stackdriver-sandbox\"",
+        "metric.label.\"response_code\"=\"200\"",
+        "metadata.user_labels.\"app\"=\"frontend\""
+      ])
+
+      range {
+
+        # By not setting a min value, it is automatically set to -infinity
+        # The upper bound for latency is 500 ms
+        max = 500
+
+      }
+    }
+  }
+}

--- a/terraform/monitoring/04_alerting_policies.tf
+++ b/terraform/monitoring/04_alerting_policies.tf
@@ -1,0 +1,61 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Create an alerting policy on the Availability SLO for the frontend service.
+# The definition of the SLO can be found in the file '03_service_slo.tf'.
+# We alert on budget burn rate, alerting if burn rate exceeds twice the allotted burn rate
+# within the past hour. 
+resource "google_monitoring_alert_policy" "frontend_availability_slo_alert" {
+  display_name = "Frontend Service Availability Alert Policy"
+  combiner     = "AND"
+  conditions {
+    display_name = "SLO burn rate alert for availability SLO with a threshold of 2"
+    condition_threshold {
+
+      # This filter alerts on burn rate over the past 60 minutes
+      filter     = "select_slo_burn_rate(\"projects/${var.project_id}/services/${google_monitoring_custom_service.frontend.service_id}/serviceLevelObjectives/${google_monitoring_slo.frontend_availability_slo.slo_id}\", 60m)"
+      
+      # The threshhold is determined by how quickly we burn through our error budget, and we alert if we will use our error budget within 15 days.
+      # Details: https://landing.google.com/sre/workbook/chapters/alerting-on-slos/#4-alert-on-burn-rate 
+      threshold_value = "2"
+      comparison = "COMPARISON_GT"
+      duration   = "60s"
+    }
+  }
+  documentation {
+    content = "Availability SLO burn for the frontend service for the past 60m exceeded twice the acceptable budget burn rate. The service is returning less OK responses than desired. Consider viewing the service logs or custom dashboard to retrieve more information or adjust the values for the SLO and error budget."
+    mime_type = "text/markdown"
+  }
+}
+
+# Create another alerting policy, this time on the SLO for latency for the frontend service.
+# Again we alert on error budget burn rate, alerting if we burn more than twice our allotted budget within
+# the past 60 minutes.
+resource "google_monitoring_alert_policy" "frontend_latency_slo_alert" {
+  display_name = "Frontend Service Latency Alert Policy"
+  combiner     = "AND"
+  conditions {
+    display_name = "SLO burn rate alert for latency SLO with a threshold of 2"
+    condition_threshold {
+      filter     = "select_slo_burn_rate(\"projects/${var.project_id}/services/${google_monitoring_custom_service.frontend.service_id}/serviceLevelObjectives/${google_monitoring_slo.frontend_latency_slo.slo_id}\", 60m)"
+      threshold_value = "2"
+      comparison = "COMPARISON_GT"
+      duration   = "60s"
+    }
+  }
+  documentation {
+    content = "Latency SLO burn for the frontend service for the past 60m exceeded twice the acceptable budget burn rate. The service is responding slower than desired. Consider viewing the service logs or custom dashboard to retrieve more information or adjust the values for the SLO and error budget."
+    mime_type = "text/markdown"
+  }
+}

--- a/tests/monitoring_integration_test.py
+++ b/tests/monitoring_integration_test.py
@@ -123,11 +123,7 @@ class TestMonitoringDashboard(unittest.TestCase):
 		found_dash = self.checkForDashboard('Ad Service Dashboard')
 		self.assertTrue(found_dash)
 
-	def testRecommendationServiceDashboard(self):
-		"""" Test that the Recommendation Service Dashboard gets created. """
-		found_dash = self.checkForDashboard('Recommendation Service Dashboard')
-
-  def testFrontendServiceDashboard(self):
+	def testFrontendServiceDashboard(self):
 		""" Test that the Frontend Service Dashboard gets created. """
 		found_dashboard = self.checkForDashboard('Frontend Service Dashboard')
 		self.assertTrue(found_dashboard)
@@ -146,6 +142,55 @@ class TestMonitoringDashboard(unittest.TestCase):
 		""" Test that the Shipping Service Dashboard gets created. """
 		found_dashboard = self.checkForDashboard('Shipping Service Dashboard')
 		self.assertTrue(found_dashboard)
+
+class TestCustomService(unittest.TestCase):
+	def setUp(self):
+		self.client = monitoring_v3.ServiceMonitoringServiceClient()
+		self.project_id = getProjectId()
+
+	def checkForService(self, service_name):
+		name = self.client.service_path(self.project_id, service_name)
+		return self.client.get_service(name)
+
+	def testFrontendServiceExists(self):
+		""" Test that the Frontend Custom Service gets created. """
+		response = self.checkForService('frontend-srv')
+		# check that we found an object
+		self.assertTrue(response)
+
+class TestServiceSlo(unittest.TestCase):
+	def setUp(self):
+		self.client = monitoring_v3.ServiceMonitoringServiceClient()
+		self.project_id = getProjectId()
+
+	def checkForSlo(self, service, slo):
+		name = self.client.service_level_objective_path(self.project_id, service, slo)
+		return self.client.get_service_level_objective(name)
+
+	def testFrontendServiceSloExists(self):
+		""" Test that for each service that two SLOs (availability, latency) get created. """
+		found_availability_slo = self.checkForSlo('frontend-srv', 'availability-slo')
+		self.assertTrue(found_availability_slo)
+		found_latency_slo = self.checkForSlo('frontend-srv', 'latency-slo')
+		self.assertTrue(found_latency_slo)
+
+class TestSloAlertPolicy(unittest.TestCase):
+	def setUp(self):
+		self.client = monitoring_v3.AlertPolicyServiceClient()
+
+	def checkForAlertingPolicy(self, policy_display_name):
+		policies = self.client.list_alert_policies(project_name)
+		for policy in policies:
+			if policy.display_name == policy_display_name:
+				return True
+		return False
+
+	def testFrontendServiceSloAlertExists(self):
+		""" Test that the Alerting Policies for the Frontend Service SLO get created. """
+		found_availability_alert = self.checkForAlertingPolicy('Frontend Service Availability Alert Policy')
+		self.assertTrue(found_availability_alert)
+		found_latency_alert = self.checkForAlertingPolicy('Frontend Service Latency Alert Policy')
+		self.assertTrue(found_latency_alert)
 
 if __name__ == '__main__':
 	project_name = project_name + getProjectId()


### PR DESCRIPTION
#WHAT: 1 availability and 1 latency SLO for the frontend and an alerting policy on error budget burn rate for each SLO.

#WHY: We want to have alerting policies on SLOs for each service since SLO setting and alerting on budget burn is part of good practice for monitoring

#HOW: Terraform resources for each custom service, SLO, and alerting policy.

#TESTING: Created tests for all created resources to ensure they are created. Content of each resource verified manually.

#Note: I'm a little iffy on the SLOs - if you notice they are set to 80% good/total because otherwise they will all fail and burn through their entire error budget. 80% does seem like a very low number to me for an SLO, but I do think the definition is correct.

Closes #70