### PR TITLE
Adding google.com accounts support and terraform stateful provisioning

### DIFF
--- a/terraform/00_state.tf
+++ b/terraform/00_state.tf
@@ -16,22 +16,28 @@
 # backend which stores everything in a local directory. The config you see below
 # is functionally equivalent to the defaults.
 
-terraform {
-  backend "local" {
-    path = "terraform.tfstate"
-  }
-}
+#terraform {
+#  backend "local" {
+#    path = "terraform.tfstate"
+#  }
+#}
 
 # TODO - Consider storing state remotely on a per-instance basis. 
 # In that case we'd generate a backend config just before
 # running terraform that would look something like this:
 
-# terraform {
-#   backend "gcs" {
-#     bucket = "stackdriver-sandbox"
-#     prefix = "<project-id>"
-#   }
-# }
+terraform {
+   backend "gcs" {
+       bucket="stackdriver-sandbox-1882647097-bucket"
+   }
+}
+
+data "terraform_remote_state" "state" {
+    backend = "gcs"
+    config = {
+        bucket = "${var.bucket_name}"
+    }
+}
 
 # Interpolations are not supported in backend configs so we'd have to generate
 # the file rather than rely on env vars like we can do almost everywhere else.

--- a/terraform/00_state.tf
+++ b/terraform/00_state.tf
@@ -27,9 +27,7 @@
 # running terraform that would look something like this:
 
 terraform {
-   backend "gcs" {
-       bucket="stackdriver-sandbox-1882647097-bucket"
-   }
+   backend "gcs" {}
 }
 
 data "terraform_remote_state" "state" {

--- a/terraform/00_state.tf
+++ b/terraform/00_state.tf
@@ -12,6 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+# We are now using gcs as our backend, so the state file will be stored
+# in a storage bucket. Since the bucket must preexists, we will create 
+# the project and bucket outside Terraform. Also since the configuration
+# of bucket can't be a variable, we create an empty config and modify it
+# in the data section.
+
 terraform {
    backend "gcs" {}
 }

--- a/terraform/00_state.tf
+++ b/terraform/00_state.tf
@@ -12,20 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Here we configure the state backend. For this demo we're using the "local"
-# backend which stores everything in a local directory. The config you see below
-# is functionally equivalent to the defaults.
-
-#terraform {
-#  backend "local" {
-#    path = "terraform.tfstate"
-#  }
-#}
-
-# TODO - Consider storing state remotely on a per-instance basis. 
-# In that case we'd generate a backend config just before
-# running terraform that would look something like this:
-
 terraform {
    backend "gcs" {}
 }
@@ -36,6 +22,3 @@ data "terraform_remote_state" "state" {
         bucket = "${var.bucket_name}"
     }
 }
-
-# Interpolations are not supported in backend configs so we'd have to generate
-# the file rather than rely on env vars like we can do almost everywhere else.

--- a/terraform/00_state.tf
+++ b/terraform/00_state.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-# We are now using gcs as our backend, so the state file will be stored
+# We use gcs as our backend, so the state file will be stored
 # in a storage bucket. Since the bucket must preexists, we will create 
 # the project and bucket outside Terraform. Also since the configuration
 # of bucket can't be a variable, we create an empty config and modify it

--- a/terraform/02_project.tf
+++ b/terraform/02_project.tf
@@ -23,30 +23,34 @@ data "google_billing_account" "acct" {
   display_name = "${var.billing_account}"
 }
 
+data "google_project" "project" {
+  project_id = "${var.project_id}"
+}
+
 # This generates a random project id that starts with "stackdriver-sandbox-" and
 # ends with a random number in the unsigned int range. See the docs for more:
 # https://www.terraform.io/docs/providers/random/r/id.html
-resource "random_id" "project" {
-  prefix      = "stackdriver-sandbox-"
-  byte_length = "4"
-}
+#resource "random_id" "project" {
+#  prefix      = "stackdriver-sandbox-"
+#  byte_length = "4"
+#}
 
 # Here we create the actual project.
-resource "google_project" "project" {
-  name = "Stackdriver Sandbox Demo"
-
-  # This references the random project ID we created above; note that we're
-  # asking for the `dec` attribute which returns the number in decimal format
-  project_id = "${random_id.project.dec}"
-
-  # This references the billing account that we looked up before. Note the
-  # `data.` prefix vs. using the resource name directly as we did above with
-  # `random_id.`
-  billing_account = "${data.google_billing_account.acct.id}"
-}
+#resource "google_project" "project" {
+#  name = "Stackdriver Sandbox Demo"
+#
+#  # This references the random project ID we created above; note that we're
+#  # asking for the `dec` attribute which returns the number in decimal format
+#  project_id = "${random_id.project.dec}"
+#
+#  # This references the billing account that we looked up before. Note the
+#  # `data.` prefix vs. using the resource name directly as we did above with
+#  # `random_id.`
+#  billing_account = "${data.google_billing_account.acct.id}"
+#}
 
 resource "google_project_service" "iam" {
-  project = "${google_project.project.id}"
+  project = "${data.google_project.project.id}"
 
   service = "iam.googleapis.com"
 
@@ -54,7 +58,7 @@ resource "google_project_service" "iam" {
 }
 
 resource "google_project_service" "compute" {
-  project = "${google_project.project.id}"
+  project = "${data.google_project.project.id}"
 
   service = "compute.googleapis.com"
 
@@ -62,7 +66,7 @@ resource "google_project_service" "compute" {
 }
 
 resource "google_project_service" "clouddebugger" {
-  project = "${google_project.project.id}"
+  project = "${data.google_project.project.id}"
 
   service = "clouddebugger.googleapis.com"
 
@@ -71,7 +75,7 @@ resource "google_project_service" "clouddebugger" {
 
 
 resource "google_project_service" "cloudtrace" {
-  project = "${google_project.project.id}"
+  project = "${data.google_project.project.id}"
 
   service = "cloudtrace.googleapis.com"
 
@@ -79,7 +83,7 @@ resource "google_project_service" "cloudtrace" {
 }
 
 resource "google_project_service" "errorreporting" {
-  project = "${google_project.project.id}"
+  project = "${data.google_project.project.id}"
 
   service = "clouderrorreporting.googleapis.com"
 
@@ -106,7 +110,7 @@ resource "google_project_service" "gke" {
   # and then we don't have to specify this on every resource any more.
   #
   # Anyway, expect to see a lot more of these. I won't explain every time.
-  project = "${google_project.project.id}"
+  project = "${data.google_project.project.id}"
 
   # the service URI we want to enable
   service = "container.googleapis.com"

--- a/terraform/02_project.tf
+++ b/terraform/02_project.tf
@@ -27,28 +27,6 @@ data "google_project" "project" {
   project_id = "${var.project_id}"
 }
 
-# This generates a random project id that starts with "stackdriver-sandbox-" and
-# ends with a random number in the unsigned int range. See the docs for more:
-# https://www.terraform.io/docs/providers/random/r/id.html
-#resource "random_id" "project" {
-#  prefix      = "stackdriver-sandbox-"
-#  byte_length = "4"
-#}
-
-# Here we create the actual project.
-#resource "google_project" "project" {
-#  name = "Stackdriver Sandbox Demo"
-#
-#  # This references the random project ID we created above; note that we're
-#  # asking for the `dec` attribute which returns the number in decimal format
-#  project_id = "${random_id.project.dec}"
-#
-#  # This references the billing account that we looked up before. Note the
-#  # `data.` prefix vs. using the resource name directly as we did above with
-#  # `random_id.`
-#  billing_account = "${data.google_billing_account.acct.id}"
-#}
-
 resource "google_project_service" "iam" {
   project = "${data.google_project.project.id}"
 

--- a/terraform/03_gke_cluster.tf
+++ b/terraform/03_gke_cluster.tf
@@ -23,7 +23,7 @@ resource "random_shuffle" "zone" {
   # found that it only ever picked `us-central-1c` unless we seeded it. Here
   # we're using the ID of the project as a seed because it is unique to the
   # project but will not change, thereby guaranteeing stability of the results.
-  seed = "${google_project.project.id}"
+  seed = "${data.google_project.project.id}"
 }
 
 # First we create the cluster. If you're wondering where all the sizing details
@@ -40,7 +40,7 @@ resource "random_shuffle" "zone" {
 # replicates what the Hipster Shop README creates. If you want to see what else
 # is possible, check out the docs: https://www.terraform.io/docs/providers/google/r/container_cluster.html
 resource "google_container_cluster" "gke" {
-  project = "${google_project.project.id}"
+  project = "${data.google_project.project.id}"
 
   # Here's how you specify the name
   name = "stackdriver-sandbox"
@@ -111,7 +111,7 @@ resource "google_container_cluster" "gke" {
 # Set current project 
 resource "null_resource" "current_project" {
   provisioner "local-exec" {
-    command = "gcloud config set project ${google_project.project.id}"
+    command = "gcloud config set project ${data.google_project.project.id}"
   }
 }
 
@@ -126,7 +126,7 @@ resource "null_resource" "current_project" {
 # Setting kubectl context to currently deployed GKE cluster
 resource "null_resource" "set_gke_context" {
   provisioner "local-exec" {
-    command = "gcloud container clusters get-credentials stackdriver-sandbox --zone ${element(random_shuffle.zone.result, 0)} --project ${google_project.project.id}"
+    command = "gcloud container clusters get-credentials stackdriver-sandbox --zone ${element(random_shuffle.zone.result, 0)} --project ${data.google_project.project.id}"
   }
 
   depends_on = [

--- a/terraform/destroy.sh
+++ b/terraform/destroy.sh
@@ -61,4 +61,5 @@ fi
 # remove tfstate file so a new project id will be generated next time
 log "removing tfstate file"
 rm -f terraform.tfstate
+rm -f .terraform/terraform.tfstate
 log "Stackdriver Sandbox resources deleted"

--- a/terraform/destroy.sh
+++ b/terraform/destroy.sh
@@ -60,6 +60,5 @@ fi
 
 # remove tfstate file so a new project id will be generated next time
 log "removing tfstate file"
-rm -f terraform.tfstate
 rm -f .terraform/terraform.tfstate
 log "Stackdriver Sandbox resources deleted"

--- a/terraform/install.sh
+++ b/terraform/install.sh
@@ -86,7 +86,7 @@ getProject() {
       found_projects+=("$bill_proj | $create_time")
     fi
   done
-  
+
   if [ -z "$found_projects" ] || [[ ${#found_projects[@]} -eq 0 ]]; then
     createProject;
   else
@@ -123,11 +123,12 @@ createProject() {
     if [[ $acct == *"google.com"* ]];
     then
       log ""
-      log "Are you sure you have requested access to /experimental-gke folder?"
-      log "If not, please make a request at https://sphinx.corp.google.com/sphinx/#accessChangeRequest:systemName=internal_google_cloud_platform_usage"
+      log "Note: your project will be created in the /experimental-gke folder."
+      log "If you don't have access to this folder, please make sure to request at:"
+      log "https://sphinx.corp.google.com/sphinx/#accessChangeRequest:systemName=internal_google_cloud_platform_usage"
       log ""
-      select opt in "yes" "no"; do
-        if [[ "$opt" == "yes" ]]; then
+      select opt in "continue" "cancel"; do
+        if [[ "$opt" == "continue" ]]; then
           break;
         else
           exit 0;
@@ -235,7 +236,7 @@ log "Checking Prerequisites..."
 getBillingAccount;
 
 log "Install current version of Terraform"
-#installTerraform
+installTerraform
 
 # Make sure we use Application Default Credentials for authentication
 # For that we need to unset GOOGLE_APPLICATION_CREDENTIALS and generate

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -20,3 +20,13 @@ variable "billing_account" {
   type        = "string"
   description = "The name of your billing account. Case-sensitive."
 }
+
+variable "project_id" {
+  type        = "string"
+  description = "The id of your project. Case-sensitive."
+}
+
+variable "bucket_name" {
+  type        = "string"
+  description = "The name of your bucket. Case-sensitive."
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -28,5 +28,5 @@ variable "project_id" {
 
 variable "bucket_name" {
   type        = "string"
-  description = "The name of your bucket. Case-sensitive."
+  description = "The name of your bucket to store the state file. Case-sensitive."
 }


### PR DESCRIPTION
1. Implement the project creation process: create a project and a bucket and link the billing account.
2. Implement the project choosing process: let user to choose an existing project or create a new one.
3. Switch the Terraform backend from local to remote: Interpolate the bucket name in the backend config.

Update:
1. Add support to google.com account: projects should now be in /experimental-gke.
2. Change the way to get the billing ID: use a map to store (name:id) to avoid fuzzy search supported by the gcloud filter flag.
3. Remove code remarks and make code clean.

Update2:
1. Change the way to ensure bucket is created: put it in a retry loop.
2. Now it only fetches the projects under certain billing account.
3. Shows project creation time on the prompt.