### PR TITLE
Changed node type to n1-standard-2

### DIFF
--- a/terraform/03_gke_cluster.tf
+++ b/terraform/03_gke_cluster.tf
@@ -67,6 +67,8 @@ resource "google_container_cluster" "gke" {
   # interesting things.
   node_pool {
     node_config {
+      machine_type = "n1-standard-2"
+
       oauth_scopes = [
         "https://www.googleapis.com/auth/cloud-platform"  
       ]
@@ -76,8 +78,8 @@ resource "google_container_cluster" "gke" {
         cluster = "stackdriver-sandbox-main"   
       }
     }
-    
-    initial_node_count = 7
+
+    initial_node_count = 4
 
     autoscaling {
       min_node_count = 3


### PR DESCRIPTION
fixes https://github.com/GoogleCloudPlatform/stackdriver-sandbox/issues/212

Change from 7xn1-standard-1 nodes to 4xn1-standard-2, to consume fewer IP resources