### PR TITLE
Update Cloud Shell Button URL

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -56,7 +56,7 @@
       <div class="steps">
         <div class="step step-1">
           <!--label>Step 1</label-->
-          <a class="console-btn" href="https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/stackdriver-sandbox.git&cloudshell_git_branch=v0.1.14&cloudshell_working_dir=terraform&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image" target="_blank" onclick="metrics.recordCustomTime('stackdriver-demo-open-in-cloud-shell')">Open in Google Cloud Shell</a>
+          <a class="console-btn" href="https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/stackdriver-sandbox.git&cloudshell_git_branch=v0.1.14&cloudshell_working_dir=terraform&shellonly=true" target="_blank" onclick="metrics.recordCustomTime('stackdriver-demo-open-in-cloud-shell')">Open in Google Cloud Shell</a>
         </div>
         <img src="images/bg_02.png" class="cloud-shell" alt="cloud shell">
       </div>


### PR DESCRIPTION
- Remove the custom Cloud Shell image from the website until the ongoing issue is resolved
- remove the Cloud Shell editor pane (https://github.com/GoogleCloudPlatform/stackdriver-sandbox/issues/232)