### PR TITLE
Add owner permission check and credential check

### DIFF
--- a/terraform/00_state.tf
+++ b/terraform/00_state.tf
@@ -26,6 +26,6 @@ terraform {
 data "terraform_remote_state" "state" {
     backend = "gcs"
     config = {
-        bucket = "${var.bucket_name}"
+        bucket = var.bucket_name
     }
 }

--- a/terraform/02_project.tf
+++ b/terraform/02_project.tf
@@ -20,15 +20,15 @@
 #
 # If productized we'd drop this and use the default billing account instead.
 data "google_billing_account" "acct" {
-  display_name = "${var.billing_account}"
+  display_name = var.billing_account
 }
 
 data "google_project" "project" {
-  project_id = "${var.project_id}"
+  project_id = var.project_id
 }
 
 resource "google_project_service" "iam" {
-  project = "${data.google_project.project.id}"
+  project = data.google_project.project.id
 
   service = "iam.googleapis.com"
 
@@ -36,7 +36,7 @@ resource "google_project_service" "iam" {
 }
 
 resource "google_project_service" "compute" {
-  project = "${data.google_project.project.id}"
+  project = data.google_project.project.id
 
   service = "compute.googleapis.com"
 
@@ -44,7 +44,7 @@ resource "google_project_service" "compute" {
 }
 
 resource "google_project_service" "clouddebugger" {
-  project = "${data.google_project.project.id}"
+  project = data.google_project.project.id
 
   service = "clouddebugger.googleapis.com"
 
@@ -53,7 +53,7 @@ resource "google_project_service" "clouddebugger" {
 
 
 resource "google_project_service" "cloudtrace" {
-  project = "${data.google_project.project.id}"
+  project = data.google_project.project.id
 
   service = "cloudtrace.googleapis.com"
 
@@ -61,7 +61,7 @@ resource "google_project_service" "cloudtrace" {
 }
 
 resource "google_project_service" "errorreporting" {
-  project = "${data.google_project.project.id}"
+  project = data.google_project.project.id
 
   service = "clouderrorreporting.googleapis.com"
 
@@ -88,7 +88,7 @@ resource "google_project_service" "gke" {
   # and then we don't have to specify this on every resource any more.
   #
   # Anyway, expect to see a lot more of these. I won't explain every time.
-  project = "${data.google_project.project.id}"
+  project = data.google_project.project.id
 
   # the service URI we want to enable
   service = "container.googleapis.com"

--- a/terraform/03_gke_cluster.tf
+++ b/terraform/03_gke_cluster.tf
@@ -23,7 +23,7 @@ resource "random_shuffle" "zone" {
   # found that it only ever picked `us-central-1c` unless we seeded it. Here
   # we're using the ID of the project as a seed because it is unique to the
   # project but will not change, thereby guaranteeing stability of the results.
-  seed = "${data.google_project.project.id}"
+  seed = data.google_project.project.id
 }
 
 # First we create the cluster. If you're wondering where all the sizing details
@@ -40,7 +40,7 @@ resource "random_shuffle" "zone" {
 # replicates what the Hipster Shop README creates. If you want to see what else
 # is possible, check out the docs: https://www.terraform.io/docs/providers/google/r/container_cluster.html
 resource "google_container_cluster" "gke" {
-  project = "${data.google_project.project.id}"
+  project = data.google_project.project.id
 
   # Here's how you specify the name
   name = "stackdriver-sandbox"
@@ -48,7 +48,7 @@ resource "google_container_cluster" "gke" {
   # Set the zone by grabbing the result of the random_shuffle above. It
   # returns a list so we have to pull the first element off. If you're looking
   # at this and thinking "huh terraform syntax looks a clunky" you are NOT WRONG
-  zone = "${element(random_shuffle.zone.result, 0)}"
+  zone = element(random_shuffle.zone.result, 0)
 
   # Using an embedded resource to define the node pool. Another
   # option would be to create the node pool as a separate resource and link it
@@ -106,7 +106,7 @@ resource "google_container_cluster" "gke" {
   # be enabled) before the cluster can be created. This will not address the
   # eventual consistency problems we have with the API but it will make sure
   # that we're at least trying to do things in the right order.
-  depends_on = ["google_project_service.gke"]
+  depends_on = [google_project_service.gke]
 }
 
 
@@ -122,7 +122,7 @@ resource "null_resource" "current_project" {
 #      command = "sleep 60 >./stdout.log 2>./stderr.log & echo \"sleeping in PID\" $!"
 #  }
 #
-#  depends_on = ["google_container_cluster.gke"]
+#  depends_on = [google_container_cluster.gke]
 #}
 
 # Setting kubectl context to currently deployed GKE cluster
@@ -132,8 +132,8 @@ resource "null_resource" "set_gke_context" {
   }
 
   depends_on = [
-    "google_container_cluster.gke", 
-    "null_resource.current_project"
+    google_container_cluster.gke, 
+    null_resource.current_project
   ]
 }
 
@@ -143,7 +143,7 @@ resource "null_resource" "install_istio" {
     command = "./istio/install_istio.sh"
   }
 
-  depends_on = ["null_resource.set_gke_context"]
+  depends_on = [null_resource.set_gke_context]
 }
 
 # Deploy microservices into GKE cluster 
@@ -152,7 +152,7 @@ resource "null_resource" "deploy_services" {
     command = "kubectl apply -f ../kubernetes-manifests"
   }
 
-  depends_on = ["null_resource.install_istio"]
+  depends_on = [null_resource.install_istio]
 }
 
 # We wait for all of our microservices to become available on kubernetes
@@ -172,7 +172,7 @@ resource "null_resource" "delay" {
   }
 
   triggers = {
-    "before" = "${null_resource.deploy_services.id}"
+    "before" = null_resource.deploy_services.id
   }
 }
 

--- a/terraform/destroy.sh
+++ b/terraform/destroy.sh
@@ -26,7 +26,7 @@ SCRIPT_DIR=$(realpath $(dirname "$0"))
 cd $SCRIPT_DIR
 
 # find the stackdriver sandbox project id
-found=$(gcloud projects list --filter="name:stackdriver-sandbox-*" --format="value(projectId)")
+found=$(gcloud projects list --filter="id:stackdriver-sandbox-* AND name='Stackdriver Sandbox Demo'" --format="value(projectId)")
 if [[ -z "${found}" ]]; then
     log "error: no Stackdriver Sandbox projects found"
     exit 1

--- a/terraform/install.sh
+++ b/terraform/install.sh
@@ -179,6 +179,32 @@ applyTerraform() {
   terraform apply -auto-approve -var="billing_account=${billing_acct}" -var="project_id=${project_id}" -var="bucket_name=${bucket_name}"
 }
 
+installMonitoring() {
+  log "Retrieving the external IP address of the application..."
+  TRIES=0
+  external_ip="";
+  while [[ -z $external_ip && "${TRIES}" -lt 20 ]]; do
+     external_ip=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}'); 
+     [ -z "$external_ip" ] && sleep 5; 
+     TRIES=$((TRIES + 1))
+  done;
+
+  if [[ -z $external_ip ]]; then
+    log "Could not retrieve external IP... skipping monitoring configuration."
+    return 1
+  fi
+
+  gcp_monitoring_path="https://console.cloud.google.com/monitoring?project=$project_id"
+  log "Please create a monitoring workspace for the project by clicking on the following link: $gcp_monitoring_path"
+  read -p "When you are done, please press enter to continue"
+
+  log "Creating monitoring examples (dashboards, uptime checks, alerting policies, etc.)..."
+  pushd monitoring/
+  terraform init -lock=false
+  terraform apply --auto-approve -var="project_id=${project_id}" -var="external_ip=${external_ip}"
+  popd
+}
+
 getExternalIp() {
   external_ip=""; 
   while [ -z $external_ip ]; do
@@ -251,6 +277,8 @@ getBillingAccount;
 # Provision Stackdriver Sandbox cluster
 getProject;
 applyTerraform;
+# || true to prevent errors during monitoring setup from stopping the installation script
+installMonitoring || true;
 getExternalIp;
 loadGen;
 displaySuccessMessage;

--- a/terraform/install.sh
+++ b/terraform/install.sh
@@ -179,32 +179,6 @@ applyTerraform() {
   terraform apply -auto-approve -var="billing_account=${billing_acct}" -var="project_id=${project_id}" -var="bucket_name=${bucket_name}"
 }
 
-installMonitoring() {
-  log "Retrieving the external IP address of the application..."
-  TRIES=0
-  external_ip="";
-  while [[ -z $external_ip && "${TRIES}" -lt 20 ]]; do
-     external_ip=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}'); 
-     [ -z "$external_ip" ] && sleep 5; 
-     TRIES=$((TRIES + 1))
-  done;
-
-  if [[ -z $external_ip ]]; then
-    log "Could not retrieve external IP... skipping monitoring configuration."
-    return 1
-  fi
-
-  gcp_monitoring_path="https://console.cloud.google.com/monitoring?project=$project_id"
-  log "Please create a monitoring workspace for the project by clicking on the following link: $gcp_monitoring_path"
-  read -p "When you are done, please press enter to continue"
-
-  log "Creating monitoring examples (dashboards, uptime checks, alerting policies, etc.)..."
-  pushd monitoring/
-  terraform init -lock=false
-  terraform apply --auto-approve -var="project_id=${project_id}" -var="external_ip=${external_ip}"
-  popd
-}
-
 getExternalIp() {
   external_ip=""; 
   while [ -z $external_ip ]; do
@@ -277,8 +251,6 @@ getBillingAccount;
 # Provision Stackdriver Sandbox cluster
 getProject;
 applyTerraform;
-# || true to prevent errors during monitoring setup from stopping the installation script
-installMonitoring || true;
 getExternalIp;
 loadGen;
 displaySuccessMessage;

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -17,16 +17,16 @@
 # Creating this variable but leaving it empty means that the user will be
 # prompted for a value when terraform is run
 variable "billing_account" {
-  type        = "string"
+  type        = string
   description = "The name of your billing account. Case-sensitive."
 }
 
 variable "project_id" {
-  type        = "string"
+  type        = string
   description = "The id of your project. Case-sensitive."
 }
 
 variable "bucket_name" {
-  type        = "string"
+  type        = string
   description = "The name of your bucket to store the state file. Case-sensitive."
 }


### PR DESCRIPTION
1. Add auth login when terraform init fails.
2. Add check on owner permission of a project.
3. Remove terraform warnings.
4. Adjust log wordings.