### PR TITLE
OpenTelemetry Tracing for ProductCatalogService

### DIFF
--- a/src/productcatalogservice/Dockerfile
+++ b/src/productcatalogservice/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.10-alpine AS builder
+FROM golang:1.14-alpine AS builder
 RUN apk add --no-cache ca-certificates git && \
       wget -qO/go/bin/dep https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64 && \
       chmod +x /go/bin/dep

--- a/src/productcatalogservice/Gopkg.lock
+++ b/src/productcatalogservice/Gopkg.lock
@@ -224,7 +224,7 @@
   version = "v0.22.3"
 
 [[projects]]
-  digest = "1:69f5a80734fb8b58f3b0211cdda49ba8d957db824ba81f1a840372265bffdf2f"
+  digest = "1:d756b2b40d48038459c1fdb1068a834c0f6aa839f8260e961dd1862531a63226"
   name = "go.opentelemetry.io/otel"
   packages = [
     "api/correlation",
@@ -241,6 +241,7 @@
     "api/standard",
     "api/trace",
     "api/unit",
+    "instrumentation/grpctrace",
     "internal/trace/parent",
     "sdk",
     "sdk/export/trace",
@@ -579,6 +580,8 @@
     "go.opencensus.io/trace",
     "go.opentelemetry.io/otel/api/global",
     "go.opentelemetry.io/otel/api/standard",
+    "go.opentelemetry.io/otel/api/trace",
+    "go.opentelemetry.io/otel/instrumentation/grpctrace",
     "go.opentelemetry.io/otel/sdk/resource",
     "go.opentelemetry.io/otel/sdk/trace",
     "golang.org/x/net/context",

--- a/src/productcatalogservice/Gopkg.lock
+++ b/src/productcatalogservice/Gopkg.lock
@@ -44,6 +44,14 @@
   version = "v0.1.4"
 
 [[projects]]
+  digest = "1:9fe8532210bb4a51753c8b783bb6ff4bf03da370b2440a05f5686b3b440ce930"
+  name = "github.com/GoogleCloudPlatform/opentelemetry-operations-go"
+  packages = ["exporter/trace"]
+  pruneopts = "UT"
+  revision = "a1393affee9a13ed21974ae1d791da1b3189f4a0"
+  version = "v0.2.1"
+
+[[projects]]
   digest = "1:b1e7ba6d161db9032698416c621f39d08aefc9afe441edde4010c39d7f5510e9"
   name = "github.com/aws/aws-sdk-go"
   packages = [
@@ -214,6 +222,37 @@
   pruneopts = "UT"
   revision = "d835ff86be02193d324330acdb7d65546b05f814"
   version = "v0.22.3"
+
+[[projects]]
+  digest = "1:69f5a80734fb8b58f3b0211cdda49ba8d957db824ba81f1a840372265bffdf2f"
+  name = "go.opentelemetry.io/otel"
+  packages = [
+    "api/correlation",
+    "api/global",
+    "api/global/internal",
+    "api/internal",
+    "api/kv",
+    "api/kv/value",
+    "api/label",
+    "api/metric",
+    "api/metric/registry",
+    "api/oterror",
+    "api/propagation",
+    "api/standard",
+    "api/trace",
+    "api/unit",
+    "internal/trace/parent",
+    "sdk",
+    "sdk/export/trace",
+    "sdk/instrumentation",
+    "sdk/internal",
+    "sdk/resource",
+    "sdk/trace",
+    "sdk/trace/internal",
+  ]
+  pruneopts = "UT"
+  revision = "58e50e249fe4c57f64e421e300b5d2316ae96811"
+  version = "v0.9.0"
 
 [[projects]]
   branch = "master"
@@ -527,6 +566,7 @@
     "contrib.go.opencensus.io/exporter/stackdriver",
     "contrib.go.opencensus.io/exporter/stackdriver/monitoredresource",
     "github.com/GoogleCloudPlatform/microservices-demo/src/productcatalogservice/genproto",
+    "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace",
     "github.com/golang/protobuf/jsonpb",
     "github.com/golang/protobuf/proto",
     "github.com/google/go-cmp/cmp",
@@ -537,6 +577,10 @@
     "go.opencensus.io/stats",
     "go.opencensus.io/stats/view",
     "go.opencensus.io/trace",
+    "go.opentelemetry.io/otel/api/global",
+    "go.opentelemetry.io/otel/api/standard",
+    "go.opentelemetry.io/otel/sdk/resource",
+    "go.opentelemetry.io/otel/sdk/trace",
     "golang.org/x/net/context",
     "google.golang.org/grpc",
     "google.golang.org/grpc/codes",

--- a/src/productcatalogservice/Gopkg.toml
+++ b/src/productcatalogservice/Gopkg.toml
@@ -50,6 +50,14 @@
   version = "0.22.3"
 
 [[constraint]]
+  name = "go.opentelemetry.io/otel"
+  version = "^0.9.0"
+
+[[constraint]]
+  name = "github.com/GoogleCloudPlatform/opentelemetry-operations-go"
+  version = ">=0.2.0"
+
+[[constraint]]
   branch = "master"
   name = "golang.org/x/net"
 


### PR DESCRIPTION
Resolves #248 . Subtask of #132 .

To test, deploy the sandbox and you should see this in Cloud Trace (specifically, look for Span.{server, client}-hipstershop.ProductCatalogService/{ListProducts, GetProduct}):

![image](https://user-images.githubusercontent.com/25183001/89335737-45cb5200-d64d-11ea-9bc8-737558dd6855.png)

![image](https://user-images.githubusercontent.com/25183001/89335809-5da2d600-d64d-11ea-8229-13eea78b61e3.png)
