### PR TITLE
[Do Not Merge] Integrate Cloud Shell in release process

### DIFF
--- a/.github/workflows/push-tags.yml
+++ b/.github/workflows/push-tags.yml
@@ -25,16 +25,16 @@ jobs:
     - name: Get the version
       id: get_version
       run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
-    - name: Push Service Images to GCR
-      timeout-minutes: 20
-      run: |
-        set -x
-        skaffold config set --global local-cluster false
-        # tag with release version
-        skaffold build --default-repo=gcr.io/$PROJECT_ID \
-                       --tag=${{ steps.get_version.outputs.VERSION  }}
-      env:
-        PROJECT_ID: ${{ secrets.PROJECT_ID }}
+    #- name: Push Service Images to GCR
+    #  timeout-minutes: 20
+    #  run: |
+    #    set -x
+    #    skaffold config set --global local-cluster false
+    #    # tag with release version
+    #    skaffold build --default-repo=gcr.io/$PROJECT_ID \
+    #                   --tag=${{ steps.get_version.outputs.VERSION  }}
+    #  env:
+    #    PROJECT_ID: ${{ secrets.PROJECT_ID }}
     - name: Push to Cloud Shell Image GCR
       timeout-minutes: 20
       run: |

--- a/.github/workflows/push-tags.yml
+++ b/.github/workflows/push-tags.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Get the version
       id: get_version
       run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
-    - name: Push to GCR
+    - name: Push Service Images to GCR
       timeout-minutes: 20
       run: |
         set -x
@@ -33,5 +33,15 @@ jobs:
         # tag with release version
         skaffold build --default-repo=gcr.io/$PROJECT_ID \
                        --tag=${{ steps.get_version.outputs.VERSION  }}
+      env:
+        PROJECT_ID: ${{ secrets.PROJECT_ID }}
+    - name: Push to Cloud Shell Image GCR
+      timeout-minutes: 20
+      run: |
+        set -x
+        gcloud auth configure-docker
+        IMAGE_PATH=gcr.io/$PROJECT_ID/cloudshell-image:${{ steps.get_version.outputs.VERSION }}
+        docker build $IMAGE_PATH -t./cloud-shell
+        docker push $IMAGE_PATH
       env:
         PROJECT_ID: ${{ secrets.PROJECT_ID }}

--- a/.github/workflows/push-tags.yml
+++ b/.github/workflows/push-tags.yml
@@ -14,6 +14,9 @@
 
 name: "Push Tagged Images"
 on:
+  push:
+    branches:
+      - cloudshell-release-scripts
   create:
     tags:
       - v*

--- a/make-release.sh
+++ b/make-release.sh
@@ -32,6 +32,7 @@ find "${REPO_ROOT}/kubernetes-manifests" -name '*.yaml' -exec sed -i -e "s/:late
 
 # update website deployment tag
 sed -i -e "s/cloudshell_git_branch=v\([0-9\.]\+\)/cloudshell_git_branch=${NEW_VERSION}/g" ${REPO_ROOT}/docs/index.html;
+sed -i -e "s/cloudshell-image:v\([0-9\.]\+\)/cloudshell-image:${NEW_VERSION}/g" ${REPO_ROOT}/docs/index.html;
 
 # if dry-run mode, exit directly after modifying files
 if [[ "$*" == *dryrun*  || "$*" == *dry-run* ]]; then


### PR DESCRIPTION
In prep for tomorrow's release

fixes https://github.com/GoogleCloudPlatform/stackdriver-sandbox/issues/226
- make-release.sh will now update the website cloud shell button to reference the new cloud shell image tag
- our release automation will build and push new images for the cloud shell image