### PR TITLE
add project to monitoring terraform provider

### DIFF
--- a/terraform/monitoring/00_provider.tf
+++ b/terraform/monitoring/00_provider.tf
@@ -27,7 +27,7 @@ provider "google" {
   version = ">=3.23.0"
 
   # credentials = "/path/to/creds.json"
-  # project = "project-id"
+  project = "var.project_id"
   # region = "default-region"
   # zone = "default-zone"
 } 

--- a/terraform/monitoring/02_dashboards.tf
+++ b/terraform/monitoring/02_dashboards.tf
@@ -69,7 +69,7 @@ variable "services" {
 # the template file defined in the 'dashboards' folder.
 data "template_file" "dash_json" {
   template = "${file("./dashboards/generic_dashboard.tmpl")}"
-  count    = "${length(var.services)}"
+  count    = "length(var.services)"
   vars     = {
     service_name = "${var.services[count.index].service_name}"
     service_id   = "${var.services[count.index].service_id}"
@@ -79,7 +79,7 @@ data "template_file" "dash_json" {
 # Create GCP Monitoring Dashboards using the rendered template files that were created in the data
 # resource above. This produces one dashboard for each microservice that we defined above.
 resource "google_monitoring_dashboard" "service_dashboards" {
-  count = "${length(var.services)}"
+  count = "length(var.services)"
   dashboard_json = <<EOF
 ${data.template_file.dash_json[count.index].rendered}
 EOF

--- a/terraform/monitoring/variables.tf
+++ b/terraform/monitoring/variables.tf
@@ -18,16 +18,16 @@
 # Currently we need the user to provide some basic information to set up the monitoring examples
 # These will be gone when we merge the monitoring terraform with the provisioning terraform
 variable "external_ip" {
-  type        = "string"
+  type        = string
   description = "The external IP of the kubernetes cluster. Can be revealed by running \"kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}'\" in the Google Cloud CLI."
 }
 
 variable "project_id" {
-  type        = "string"
+  type        = string
   description = "The project id that was created by Stackdriver Sandbox. Can be revealed by running \"gcloud config get-value project\" in the Google Cloud CLI."
 }
 
 variable "project_owner_email" {
-	type	      = "string"
+	type	      = string
 	description = "The email to receive alerts caused by violations of alerting policies."
 }


### PR DESCRIPTION
We're running into an issue where Terraform seems to think there is no configured project for the monitored resource. This fix sets the project for the provider so that won't be an issue.

Not sure why the issue exists for some projects and not for others, this should fix it universally.


Also updating the types for the variables to suppress the warnings.

Closes #258 