### PR TITLE
fix email and deprecations

### DIFF
--- a/terraform/03_gke_cluster.tf
+++ b/terraform/03_gke_cluster.tf
@@ -48,7 +48,7 @@ resource "google_container_cluster" "gke" {
   # Set the zone by grabbing the result of the random_shuffle above. It
   # returns a list so we have to pull the first element off. If you're looking
   # at this and thinking "huh terraform syntax looks a clunky" you are NOT WRONG
-  zone = element(random_shuffle.zone.result, 0)
+  location = element(random_shuffle.zone.result, 0)
 
   # Using an embedded resource to define the node pool. Another
   # option would be to create the node pool as a separate resource and link it

--- a/terraform/install.sh
+++ b/terraform/install.sh
@@ -194,6 +194,8 @@ installMonitoring() {
     return 1
   fi
 
+  acct=$(gcloud info --format="value(config.account)")
+
   gcp_monitoring_path="https://console.cloud.google.com/monitoring?project=$project_id"
   log "Please create a monitoring workspace for the project by clicking on the following link: $gcp_monitoring_path"
   read -p "When you are done, please press enter to continue"
@@ -201,7 +203,7 @@ installMonitoring() {
   log "Creating monitoring examples (dashboards, uptime checks, alerting policies, etc.)..."
   pushd monitoring/
   terraform init -lock=false
-  terraform apply --auto-approve -var="project_id=${project_id}" -var="external_ip=${external_ip}"
+  terraform apply --auto-approve -var="project_id=${project_id}" -var="external_ip=${external_ip}" -var="project_owner_email=${acct}"
   popd
 }
 

--- a/terraform/monitoring/02_dashboards.tf
+++ b/terraform/monitoring/02_dashboards.tf
@@ -69,7 +69,7 @@ variable "services" {
 # the template file defined in the 'dashboards' folder.
 data "template_file" "dash_json" {
   template = "${file("./dashboards/generic_dashboard.tmpl")}"
-  count    = "length(var.services)"
+  count    = "${length(var.services)}"
   vars     = {
     service_name = "${var.services[count.index].service_name}"
     service_id   = "${var.services[count.index].service_id}"
@@ -79,7 +79,7 @@ data "template_file" "dash_json" {
 # Create GCP Monitoring Dashboards using the rendered template files that were created in the data
 # resource above. This produces one dashboard for each microservice that we defined above.
 resource "google_monitoring_dashboard" "service_dashboards" {
-  count = "length(var.services)"
+  count = "${length(var.services)}"
   dashboard_json = <<EOF
 ${data.template_file.dash_json[count.index].rendered}
 EOF


### PR DESCRIPTION
1) Configures the user email for monitoring terraform

2) Gets rid of deprecated Zone for GKE cluster

3) Add back in the interpolation for the zone.

Closes #256 and #257 