### PR TITLE
Fix Googler authentication

### DIFF
--- a/terraform/install.sh
+++ b/terraform/install.sh
@@ -270,7 +270,7 @@ encureAuthentication() {
         log "Authentication failed"
         log "Please allow gcloud and Cloud Shell to access your GCP account"
     fi
-    while [[ -z $AUTH_ACCT  && "${TRIES}" -lt 100  ]]; do
+    while [[ -z $AUTH_ACCT  && "${TRIES}" -lt 10  ]]; do
         AUTH_ACCT=$(gcloud auth list --format="value(account)")
         sleep 3;
         TRIES=$((TRIES + 1))

--- a/terraform/install.sh
+++ b/terraform/install.sh
@@ -275,6 +275,9 @@ encureAuthentication() {
         sleep 3;
         TRIES=$((TRIES + 1))
     done
+    if [[ -z $AUTH_ACCT ]]; then
+        exit 1
+    fi
 }
 
 log "Checking Prerequisites..."

--- a/terraform/install.sh
+++ b/terraform/install.sh
@@ -263,7 +263,7 @@ displaySuccessMessage() {
     log "********************************************************************************"
 }
 
-encureAuthentication() {
+checkAuthentication() {
     TRIES=0
     AUTH_ACCT=$(gcloud auth list --format="value(account)")
     if [[ -z $AUTH_ACCT ]]; then
@@ -281,7 +281,7 @@ encureAuthentication() {
 }
 
 log "Checking Prerequisites..."
-encureAuthentication;
+checkAuthentication;
 getBillingAccount;
 
 # Make sure we use Application Default Credentials for authentication

--- a/terraform/install.sh
+++ b/terraform/install.sh
@@ -270,7 +270,7 @@ encureAuthentication() {
         log "Authentication failed"
         log "Please allow gcloud and Cloud Shell to access your GCP account"
     fi
-    while [[ -z $AUTH_ACCT  && "${TRIES}" -lt 20  ]]; do
+    while [[ -z $AUTH_ACCT  && "${TRIES}" -lt 100  ]]; do
         AUTH_ACCT=$(gcloud auth list --format="value(account)")
         sleep 3;
         TRIES=$((TRIES + 1))

--- a/terraform/install.sh
+++ b/terraform/install.sh
@@ -263,7 +263,22 @@ displaySuccessMessage() {
     log "********************************************************************************"
 }
 
+encureAuthentication() {
+    TRIES=0
+    AUTH_ACCT=$(gcloud auth list --format="value(account)")
+    if [[ -z $AUTH_ACCT ]]; then
+        log "Authentication failed"
+        log "Please authorize gcloud and Cloud Shell to your GCP account"
+    fi
+    while [[ -z $AUTH_ACCT  && "${TRIES}" -lt 20  ]]; do
+        AUTH_ACCT=$(gcloud auth list --format="value(account)")
+        sleep 5;
+        TRIES=$((TRIES + 1))
+    done
+}
+
 log "Checking Prerequisites..."
+encureAuthentication;
 getBillingAccount;
 
 # Make sure we use Application Default Credentials for authentication

--- a/terraform/install.sh
+++ b/terraform/install.sh
@@ -268,11 +268,11 @@ encureAuthentication() {
     AUTH_ACCT=$(gcloud auth list --format="value(account)")
     if [[ -z $AUTH_ACCT ]]; then
         log "Authentication failed"
-        log "Please authorize gcloud and Cloud Shell to your GCP account"
+        log "Please allow gcloud and Cloud Shell to access your GCP account"
     fi
     while [[ -z $AUTH_ACCT  && "${TRIES}" -lt 20  ]]; do
         AUTH_ACCT=$(gcloud auth list --format="value(account)")
-        sleep 5;
+        sleep 3;
         TRIES=$((TRIES + 1))
     done
 }


### PR DESCRIPTION
Added a loop to wait until gcloud is authenticated before continuing. The loop will wait for 5 minutes, and then give up

This is to get around an issue we're seeing with Google-internal accounts

Test using this link:
https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/Daniel-Sanche/stackdriver-sandbox.git&cloudshell_git_branch=fix-googler-auth&cloudshell_working_dir=terraform&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image:v0.1.14