### PR TITLE
OpenTelemetry Tracing for Checkout Service + Reuse gRPC Connections

### DIFF
--- a/src/checkoutservice/Dockerfile
+++ b/src/checkoutservice/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.10-alpine as builder
+FROM golang:1.14-alpine as builder
 RUN apk add --no-cache ca-certificates git && \
       wget -qO/go/bin/dep https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64 && \
       chmod +x /go/bin/dep

--- a/src/checkoutservice/Gopkg.lock
+++ b/src/checkoutservice/Gopkg.lock
@@ -349,7 +349,6 @@
     "github.com/sirupsen/logrus",
     "go.opencensus.io/plugin/ocgrpc",
     "go.opencensus.io/stats/view",
-    "go.opencensus.io/trace",
     "go.opentelemetry.io/otel/api/global",
     "go.opentelemetry.io/otel/api/standard",
     "go.opentelemetry.io/otel/api/trace",

--- a/src/checkoutservice/Gopkg.lock
+++ b/src/checkoutservice/Gopkg.lock
@@ -25,15 +25,6 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:1d8f3cb93c42c5652bb509fde29ecdd1feede9334e355e8bbdc0f9f95b40c254"
-  name = "git.apache.org/thrift.git"
-  packages = ["lib/go/thrift"]
-  pruneopts = "UT"
-  revision = "a5df39032ca206e2e6a9ec975147e81746d9a255"
-  source = "github.com/apache/thrift"
-
-[[projects]]
-  branch = "master"
   digest = "1:f6bdf3d8d3cbb2f98d3ebaa66b3ac25166a06830027ece7d592d9ea09dedf504"
   name = "github.com/GoogleCloudPlatform/microservices-demo"
   packages = [
@@ -42,6 +33,14 @@
   ]
   pruneopts = "UT"
   revision = "33ca3b63d82698035ffc1230dcb650885a005197"
+
+[[projects]]
+  digest = "1:9fe8532210bb4a51753c8b783bb6ff4bf03da370b2440a05f5686b3b440ce930"
+  name = "github.com/GoogleCloudPlatform/opentelemetry-operations-go"
+  packages = ["exporter/trace"]
+  pruneopts = "UT"
+  revision = "a1393affee9a13ed21974ae1d791da1b3189f4a0"
+  version = "v0.2.1"
 
 [[projects]]
   digest = "1:72856926f8208767b837bf51e3373f49139f61889b67dc7fd3c2a0fd711e3f7a"
@@ -105,7 +104,7 @@
   version = "v1.3.0"
 
 [[projects]]
-  digest = "1:a5154dfd6b37bef5a3eab759e13296348e639dc8c7604f538368167782b08ccd"
+  digest = "1:1bb914cfb78f68f488a91cd7872d3d06a5f83c5bbacf0296dbef44e120b00a91"
   name = "go.opencensus.io"
   packages = [
     ".",
@@ -126,6 +125,37 @@
   pruneopts = "UT"
   revision = "b11f239c032624b045c4c2bfd3d1287b4012ce89"
   version = "v0.16.0"
+
+[[projects]]
+  digest = "1:69f5a80734fb8b58f3b0211cdda49ba8d957db824ba81f1a840372265bffdf2f"
+  name = "go.opentelemetry.io/otel"
+  packages = [
+    "api/correlation",
+    "api/global",
+    "api/global/internal",
+    "api/internal",
+    "api/kv",
+    "api/kv/value",
+    "api/label",
+    "api/metric",
+    "api/metric/registry",
+    "api/oterror",
+    "api/propagation",
+    "api/standard",
+    "api/trace",
+    "api/unit",
+    "internal/trace/parent",
+    "sdk",
+    "sdk/export/trace",
+    "sdk/instrumentation",
+    "sdk/internal",
+    "sdk/resource",
+    "sdk/trace",
+    "sdk/trace/internal",
+  ]
+  pruneopts = "UT"
+  revision = "58e50e249fe4c57f64e421e300b5d2316ae96811"
+  version = "v0.9.0"
 
 [[projects]]
   branch = "master"
@@ -312,12 +342,17 @@
     "contrib.go.opencensus.io/exporter/stackdriver",
     "github.com/GoogleCloudPlatform/microservices-demo/src/checkoutservice/genproto",
     "github.com/GoogleCloudPlatform/microservices-demo/src/checkoutservice/money",
+    "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace",
     "github.com/golang/protobuf/proto",
     "github.com/google/uuid",
     "github.com/sirupsen/logrus",
     "go.opencensus.io/plugin/ocgrpc",
     "go.opencensus.io/stats/view",
     "go.opencensus.io/trace",
+    "go.opentelemetry.io/otel/api/global",
+    "go.opentelemetry.io/otel/api/standard",
+    "go.opentelemetry.io/otel/sdk/resource",
+    "go.opentelemetry.io/otel/sdk/trace",
     "golang.org/x/net/context",
     "google.golang.org/grpc",
     "google.golang.org/grpc/codes",

--- a/src/checkoutservice/Gopkg.lock
+++ b/src/checkoutservice/Gopkg.lock
@@ -127,7 +127,7 @@
   version = "v0.16.0"
 
 [[projects]]
-  digest = "1:69f5a80734fb8b58f3b0211cdda49ba8d957db824ba81f1a840372265bffdf2f"
+  digest = "1:d756b2b40d48038459c1fdb1068a834c0f6aa839f8260e961dd1862531a63226"
   name = "go.opentelemetry.io/otel"
   packages = [
     "api/correlation",
@@ -144,6 +144,7 @@
     "api/standard",
     "api/trace",
     "api/unit",
+    "instrumentation/grpctrace",
     "internal/trace/parent",
     "sdk",
     "sdk/export/trace",
@@ -351,6 +352,8 @@
     "go.opencensus.io/trace",
     "go.opentelemetry.io/otel/api/global",
     "go.opentelemetry.io/otel/api/standard",
+    "go.opentelemetry.io/otel/api/trace",
+    "go.opentelemetry.io/otel/instrumentation/grpctrace",
     "go.opentelemetry.io/otel/sdk/resource",
     "go.opentelemetry.io/otel/sdk/trace",
     "golang.org/x/net/context",

--- a/src/checkoutservice/Gopkg.toml
+++ b/src/checkoutservice/Gopkg.toml
@@ -50,6 +50,14 @@
   version = "0.16.0"
 
 [[constraint]]
+  name = "go.opentelemetry.io/otel"
+  version = "^0.9.0"
+
+[[constraint]]
+  name = "github.com/GoogleCloudPlatform/opentelemetry-operations-go"
+  version = ">=0.2.0"
+
+[[constraint]]
   branch = "master"
   name = "golang.org/x/net"
 

--- a/src/checkoutservice/main.go
+++ b/src/checkoutservice/main.go
@@ -159,21 +159,34 @@ func initOpenCensusStats() {
 // Initialize OTel trace provider that exports to Cloud Trace
 func initTraceProvider() {
 	projectID := os.Getenv("GOOGLE_CLOUD_PROJECT")
-	exporter, err := texporter.NewExporter(texporter.WithProjectID(projectID))
-	if err != nil {
-		log.Fatalf("failed to initialize exporter: %v", err)
+	if len(projectID) == 0 {
+		log.Warn("GOOGLE_CLOUD_PROJECT not set")
 	}
-
-	// Create trace provider with the exporter.
-	tp, err := sdktrace.NewProvider(sdktrace.WithConfig(
-		sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}),
-		sdktrace.WithSyncer(exporter),
-		// TODO: replace with predefined constant for GKE or autodetection when available
-		sdktrace.WithResource(resource.New(standard.ServiceNameKey.String("GKE"))))
-	if err != nil {
-		log.Fatal("failed to initialize trace provider: %v", err)
+	for i := 1; i <= 3; i++ {
+		exporter, err := texporter.NewExporter(texporter.WithProjectID(projectID))
+		if err != nil {
+			log.Infof("failed to initialize exporter: %v", err)
+		} else {
+			// Create trace provider with the exporter.
+			// The AlwaysSample sampling policy is used here for demonstration
+			// purposes and should not be used in production environments.
+			tp, err := sdktrace.NewProvider(sdktrace.WithConfig(
+				sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}),
+				sdktrace.WithSyncer(exporter),
+				// TODO: replace with predefined constant for GKE or autodetection when available
+				sdktrace.WithResource(resource.New(standard.ServiceNameKey.String("GKE"))))
+			if err == nil {
+				log.Info("initialized trace provider")
+				global.SetTraceProvider(tp)
+				return
+			} else {
+				d := time.Second * 10 * time.Duration(i)
+				log.Infof("sleeping %v to retry initializing trace provider", d)
+				time.Sleep(d)
+			}
+		}
 	}
-	global.SetTraceProvider(tp)
+	log.Warn("failed to initialize trace provider")
 }
 
 func initProfiling(service, version string) {


### PR DESCRIPTION
Resolves #275 and subtask of #132. 

I decided to fix #276 too because otherwise it was introducing a lot of redundant code. Previously, we opened+closed a brand new connection every time we needed to call another service; checkout is a client to 6 services and a single ShipOrder has 10+ calls. I've changed it:
(1) Added the gRPC connections to the checkout service data structure
(2) Open the connections at the start, with OC and OT telemetry interceptors/handler wrappers. 
(3) Reuse the connections for subsequent calls (they're methods that belong to the checkout service and thus have access to the connections directly).
This happens to greatly simplify the code as well.

To test, deploy hipster shop, add things to your cart, and then check out. You should see the following trace with `g.co/agent:opentelemetry0.9.0`. I added events to the checkout span so you can see the relative latencies for each task in the check out process :) 
![image](https://user-images.githubusercontent.com/25183001/89473332-6ff93e80-d737-11ea-97da-56ad195f8f75.png)

Note: Merging this earlier than the others would be best, because the checkout service acts as a client to 6 different services and is needed to propagate trace contexts.