### PR TITLE
OpenTelemetry Tracing for Shipping Service

### DIFF
--- a/src/shippingservice/Dockerfile
+++ b/src/shippingservice/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.10-alpine as builder
+FROM golang:1.14-alpine as builder
 RUN apk add --no-cache ca-certificates git && \
       wget -qO/go/bin/dep https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64 && \
       chmod +x /go/bin/dep

--- a/src/shippingservice/Gopkg.lock
+++ b/src/shippingservice/Gopkg.lock
@@ -338,7 +338,6 @@
     "github.com/sirupsen/logrus",
     "go.opencensus.io/plugin/ocgrpc",
     "go.opencensus.io/stats/view",
-    "go.opencensus.io/trace",
     "go.opentelemetry.io/otel/api/global",
     "go.opentelemetry.io/otel/api/standard",
     "go.opentelemetry.io/otel/api/trace",

--- a/src/shippingservice/Gopkg.lock
+++ b/src/shippingservice/Gopkg.lock
@@ -25,20 +25,19 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:d3a57cdbaefaceca4ebe6258ed86a992bdcfc93a8442dbda5343e2d43a8f8a6a"
-  name = "git.apache.org/thrift.git"
-  packages = ["lib/go/thrift"]
-  pruneopts = "UT"
-  revision = "67df34afa782be67154034b31e4ad7cb3834fed1"
-  source = "github.com/apache/thrift"
-
-[[projects]]
-  branch = "master"
   digest = "1:27490301253ac5063d502480ef3794b95222eea6cb997ae6e689a058b1cd5253"
   name = "github.com/GoogleCloudPlatform/microservices-demo"
   packages = ["src/shippingservice/genproto"]
   pruneopts = "UT"
   revision = "10dfd04ab174cc680ed6ffef26cc4fb09ec40404"
+
+[[projects]]
+  digest = "1:9fe8532210bb4a51753c8b783bb6ff4bf03da370b2440a05f5686b3b440ce930"
+  name = "github.com/GoogleCloudPlatform/opentelemetry-operations-go"
+  packages = ["exporter/trace"]
+  pruneopts = "UT"
+  revision = "a1393affee9a13ed21974ae1d791da1b3189f4a0"
+  version = "v0.2.1"
 
 [[projects]]
   digest = "1:72856926f8208767b837bf51e3373f49139f61889b67dc7fd3c2a0fd711e3f7a"
@@ -94,7 +93,7 @@
   version = "v1.3.0"
 
 [[projects]]
-  digest = "1:a5154dfd6b37bef5a3eab759e13296348e639dc8c7604f538368167782b08ccd"
+  digest = "1:1bb914cfb78f68f488a91cd7872d3d06a5f83c5bbacf0296dbef44e120b00a91"
   name = "go.opencensus.io"
   packages = [
     ".",
@@ -115,6 +114,38 @@
   pruneopts = "UT"
   revision = "b11f239c032624b045c4c2bfd3d1287b4012ce89"
   version = "v0.16.0"
+
+[[projects]]
+  digest = "1:d756b2b40d48038459c1fdb1068a834c0f6aa839f8260e961dd1862531a63226"
+  name = "go.opentelemetry.io/otel"
+  packages = [
+    "api/correlation",
+    "api/global",
+    "api/global/internal",
+    "api/internal",
+    "api/kv",
+    "api/kv/value",
+    "api/label",
+    "api/metric",
+    "api/metric/registry",
+    "api/oterror",
+    "api/propagation",
+    "api/standard",
+    "api/trace",
+    "api/unit",
+    "instrumentation/grpctrace",
+    "internal/trace/parent",
+    "sdk",
+    "sdk/export/trace",
+    "sdk/instrumentation",
+    "sdk/internal",
+    "sdk/resource",
+    "sdk/trace",
+    "sdk/trace/internal",
+  ]
+  pruneopts = "UT"
+  revision = "58e50e249fe4c57f64e421e300b5d2316ae96811"
+  version = "v0.9.0"
 
 [[projects]]
   branch = "master"
@@ -302,11 +333,18 @@
     "cloud.google.com/go/profiler",
     "contrib.go.opencensus.io/exporter/stackdriver",
     "github.com/GoogleCloudPlatform/microservices-demo/src/shippingservice/genproto",
+    "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace",
     "github.com/golang/protobuf/proto",
     "github.com/sirupsen/logrus",
     "go.opencensus.io/plugin/ocgrpc",
     "go.opencensus.io/stats/view",
     "go.opencensus.io/trace",
+    "go.opentelemetry.io/otel/api/global",
+    "go.opentelemetry.io/otel/api/standard",
+    "go.opentelemetry.io/otel/api/trace",
+    "go.opentelemetry.io/otel/instrumentation/grpctrace",
+    "go.opentelemetry.io/otel/sdk/resource",
+    "go.opentelemetry.io/otel/sdk/trace",
     "golang.org/x/net/context",
     "google.golang.org/grpc",
     "google.golang.org/grpc/health/grpc_health_v1",

--- a/src/shippingservice/Gopkg.toml
+++ b/src/shippingservice/Gopkg.toml
@@ -46,6 +46,14 @@
   version = "0.16.0"
 
 [[constraint]]
+  name = "go.opentelemetry.io/otel"
+  version = "^0.9.0"
+
+[[constraint]]
+  name = "github.com/GoogleCloudPlatform/opentelemetry-operations-go"
+  version = ">=0.2.0"
+
+[[constraint]]
   branch = "master"
   name = "golang.org/x/net"
 

--- a/src/shippingservice/main.go
+++ b/src/shippingservice/main.go
@@ -25,7 +25,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"go.opencensus.io/plugin/ocgrpc"
 	"go.opencensus.io/stats/view"
-	"go.opencensus.io/trace"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
@@ -81,7 +80,7 @@ func main() {
 	}
 	// TOOD: replace ocgrpc with automatic OpenTelemetry grpc metrics collector
 	srv := grpc.NewServer(grpc.StatsHandler(
-		&ocgrpc.ServerHandler{}),
+		&ocgrpc.ServerHandler{}), // TODO: replace with automatic OTel grpc metrics collector when available
 		grpc.UnaryInterceptor(grpctrace.UnaryServerInterceptor(global.TraceProvider().Tracer("shipping"))),
 		grpc.StreamInterceptor(grpctrace.StreamServerInterceptor(global.TraceProvider().Tracer("shipping"))),
 	)
@@ -156,10 +155,6 @@ func initOpenCensusStats() {
 		if err != nil {
 			log.Warnf("failed to initialize stackdriver exporter: %+v", err)
 		} else {
-			trace.RegisterExporter(exporter)
-			trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
-			log.Info("registered stackdriver tracing")
-
 			// Register the views to collect server stats.
 			view.SetReportingPeriod(60 * time.Second)
 			view.RegisterExporter(exporter)

--- a/src/shippingservice/main.go
+++ b/src/shippingservice/main.go
@@ -175,21 +175,34 @@ func initOpenCensusStats() {
 // Initialize OTel trace provider that exports to Cloud Trace
 func initTraceProvider() {
 	projectID := os.Getenv("GOOGLE_CLOUD_PROJECT")
-	exporter, err := texporter.NewExporter(texporter.WithProjectID(projectID))
-	if err != nil {
-		log.Fatalf("failed to initialize exporter: %v", err)
+	if len(projectID) == 0 {
+		log.Warn("GOOGLE_CLOUD_PROJECT not set")
 	}
-
-	// Create trace provider with the exporter.
-	tp, err := sdktrace.NewProvider(sdktrace.WithConfig(
-		sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}),
-		sdktrace.WithSyncer(exporter),
-		// TODO: replace with predefined constant for GKE or autodetection when available
-		sdktrace.WithResource(resource.New(standard.ServiceNameKey.String("GKE"))))
-	if err != nil {
-		log.Fatal("failed to initialize trace provider: %v", err)
+	for i := 1; i <= 3; i++ {
+		exporter, err := texporter.NewExporter(texporter.WithProjectID(projectID))
+		if err != nil {
+			log.Infof("failed to initialize exporter: %v", err)
+		} else {
+			// Create trace provider with the exporter.
+			// The AlwaysSample sampling policy is used here for demonstration
+			// purposes and should not be used in production environments.
+			tp, err := sdktrace.NewProvider(sdktrace.WithConfig(
+				sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}),
+				sdktrace.WithSyncer(exporter),
+				// TODO: replace with predefined constant for GKE or autodetection when available
+				sdktrace.WithResource(resource.New(standard.ServiceNameKey.String("GKE"))))
+			if err == nil {
+				log.Info("initialized trace provider")
+				global.SetTraceProvider(tp)
+				return
+			} else {
+				d := time.Second * 10 * time.Duration(i)
+				log.Infof("sleeping %v to retry initializing trace provider", d)
+				time.Sleep(d)
+			}
+		}
 	}
-	global.SetTraceProvider(tp)
+	log.Warn("failed to initialize trace provider")
 }
 
 func initProfiling(service, version string) {


### PR DESCRIPTION
Resolves #278, subtask of #132 

To test, deploy hipster shop and either (1) view your cart (which gives you a shipping quote) or (2) check out (which calls the shipping service to "ship" your items). You should see the following trace in your Cloud Trace console with `g.co/agent:opentelemetry`:

![image](https://user-images.githubusercontent.com/25183001/89473530-f01fa400-d737-11ea-8049-9241d950801d.png)
