### PR TITLE
get rid of interpolations for terraform

### DIFF
--- a/terraform/monitoring/00_provider.tf
+++ b/terraform/monitoring/00_provider.tf
@@ -27,7 +27,7 @@ provider "google" {
   version = ">=3.23.0"
 
   # credentials = "/path/to/creds.json"
-  project = "${var.project_id}"
+  project = var.project_id
   # region = "default-region"
   # zone = "default-zone"
 } 

--- a/terraform/monitoring/02_dashboards.tf
+++ b/terraform/monitoring/02_dashboards.tf
@@ -68,8 +68,8 @@ variable "services" {
 # Iterate over the services that we defined and create a dashboard template file for each one using
 # the template file defined in the 'dashboards' folder.
 data "template_file" "dash_json" {
-  template = "${file("./dashboards/generic_dashboard.tmpl")}"
-  count    = "${length(var.services)}"
+  template = file("./dashboards/generic_dashboard.tmpl")
+  count    = length(var.services)
   vars     = {
     service_name = "${var.services[count.index].service_name}"
     service_id   = "${var.services[count.index].service_id}"
@@ -79,7 +79,7 @@ data "template_file" "dash_json" {
 # Create GCP Monitoring Dashboards using the rendered template files that were created in the data
 # resource above. This produces one dashboard for each microservice that we defined above.
 resource "google_monitoring_dashboard" "service_dashboards" {
-  count = "${length(var.services)}"
+  count = length(var.services)
   dashboard_json = <<EOF
 ${data.template_file.dash_json[count.index].rendered}
 EOF


### PR DESCRIPTION
Since we're using a version > terraform 0.11.0 the interpolation syntax is deprecated and we can actually just directly call our functions/variables. 

Gets rid of warnings that the user would see.

Tested in Cloud Shell