### PR TITLE
Improve tag actions

### DIFF
--- a/.github/workflows/push-tags.yml
+++ b/.github/workflows/push-tags.yml
@@ -17,6 +17,8 @@ on:
   create:
     tags:
       - v*
+    branches-ignore:
+      - '*'
 jobs:
   push-tags:
     runs-on: [self-hosted, push-privilege]


### PR DESCRIPTION
I've noticed the push-tags action sometimes tries to run when a new branch is pushed, instead of just on tag pushes. [Example](https://github.com/GoogleCloudPlatform/stackdriver-sandbox/runs/956115563?check_suite_focus=true)

So far this hasn't been an issue, because the pipeline will fail when the tag doesn't match the expected format. To be safe though, this PR should make the Action ignore branches, and make the Action only trigger on real tag pushes