### PR TITLE
Added logic to push-master.yml to create cloud image

### DIFF
--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -36,3 +36,14 @@ jobs:
                        --tag=latest
       env:
         PROJECT_ID: ${{ secrets.PROJECT_ID }}
+        
+     - name: Push Cloud Shell Image to GCR
+      timeout-minutes: 20
+      run: |
+        set -x
+        gcloud auth configure-docker --quiet
+        IMAGE_PATH=gcr.io/$PROJECT_ID/cloudshell-image:${{ steps.get_version.outputs.VERSION }}
+        docker build -t $IMAGE_PATH ./cloud-shell
+        docker push $IMAGE_PATH
+      env:
+        PROJECT_ID: ${{ secrets.PROJECT_ID }}


### PR DESCRIPTION
Fixes #227 

Instead of creating new Cloud Image only on tags, a Custom Cloud Shell Image is also created on updates to master.

Essentially, the only change here is that the code written to Push Cloud Shell Images to GCR in `push-tags.yml` is also added to `push-master.yml`.