### PR TITLE
Added test to CI to Build Custom Cloud Shell Image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,3 +87,8 @@ jobs:
         if [[ "$ERROR_COUNT" -gt "0" ]]; then
           exit 1
         fi
+    - name: Test Custom Cloud Shell Image Build
+      run: |
+        set -x
+        # build cloud shell image
+        docker build -t custom-cloud-shell:$GITHUB_SHA ./cloud-shell

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,11 @@ jobs:
         if [[ -n $(git status -s) ]]; then
           exit 1
         fi
+    - name: Test Custom Cloud Shell Image Build
+      run: |
+        set -x
+        # build cloud shell image: it will automatically exit if there's an error in build
+        docker build -t cloud-shell ./cloud-shell
     - name: Setup Cluster
       run: |
         set -x
@@ -87,8 +92,3 @@ jobs:
         if [[ "$ERROR_COUNT" -gt "0" ]]; then
           exit 1
         fi
-    - name: Test Custom Cloud Shell Image Build
-      run: |
-        set -x
-        # build cloud shell image: it will automatically exit if there's an error in build
-        docker build -t custom-cloud-shell:$GITHUB_SHA ./cloud-shell

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,5 +90,5 @@ jobs:
     - name: Test Custom Cloud Shell Image Build
       run: |
         set -x
-        # build cloud shell image
+        # build cloud shell image: it will automatically exit if there's an error in build
         docker build -t custom-cloud-shell:$GITHUB_SHA ./cloud-shell


### PR DESCRIPTION
Fixes #215 
- Creates `docker build` command to `ci.yml` to build the image
- Specifies that if build does not work, it exits w/code 1

One down-side of adding this to CI is that building the image takes a long time. This is mainly due to the fact that it's being pulled from the Cloud Shell Base Image (a LARGE file). It took approximately 20 minutes for the CI pipeline to run within this PR.