### PR TITLE
Fix GitHub Action Push Bug

### DIFF
--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -41,8 +41,13 @@ jobs:
       run: |
         set -x
         gcloud auth configure-docker --quiet
-        IMAGE_PATH=gcr.io/$PROJECT_ID/cloudshell-image:${{ steps.get_version.outputs.VERSION }}
-        docker build -t $IMAGE_PATH ./cloud-shell
-        docker push $IMAGE_PATH
+        # build and tag with git hash
+        IMAGE_SHA=gcr.io/$PROJECT_ID/cloudshell-image:$GITHUB_SHA
+        docker build -t $IMAGE_SHA ./cloud-shell
+        docker push $IMAGE_SHA
+        # build and tag with latest
+        IMAGE_LATEST=gcr.io/$PROJECT_ID/cloudshell-image:latest
+        docker build -t $IMAGE_LATEST ./cloud-shell
+        docker push $IMAGE_LATEST
       env:
         PROJECT_ID: ${{ secrets.PROJECT_ID }}


### PR DESCRIPTION
There was another bug in the GitHub Action for pushing Cloud Shell images on each commit to master. The workflow was trying to tag it with a non-existent version label, when we really want to tag with the git sha and latest