### PR TITLE
fix project_id in terraform

### DIFF
--- a/terraform/02_project.tf
+++ b/terraform/02_project.tf
@@ -28,7 +28,7 @@ data "google_project" "project" {
 }
 
 resource "google_project_service" "iam" {
-  project = data.google_project.project.id
+  project = data.google_project.project.project_id
 
   service = "iam.googleapis.com"
 
@@ -36,7 +36,7 @@ resource "google_project_service" "iam" {
 }
 
 resource "google_project_service" "compute" {
-  project = data.google_project.project.id
+  project = data.google_project.project.project_id
 
   service = "compute.googleapis.com"
 
@@ -44,7 +44,7 @@ resource "google_project_service" "compute" {
 }
 
 resource "google_project_service" "clouddebugger" {
-  project = data.google_project.project.id
+  project = data.google_project.project.project_id
 
   service = "clouddebugger.googleapis.com"
 
@@ -53,7 +53,7 @@ resource "google_project_service" "clouddebugger" {
 
 
 resource "google_project_service" "cloudtrace" {
-  project = data.google_project.project.id
+  project = data.google_project.project.project_id
 
   service = "cloudtrace.googleapis.com"
 
@@ -61,7 +61,7 @@ resource "google_project_service" "cloudtrace" {
 }
 
 resource "google_project_service" "errorreporting" {
-  project = data.google_project.project.id
+  project = data.google_project.project.project_id
 
   service = "clouderrorreporting.googleapis.com"
 
@@ -88,7 +88,7 @@ resource "google_project_service" "gke" {
   # and then we don't have to specify this on every resource any more.
   #
   # Anyway, expect to see a lot more of these. I won't explain every time.
-  project = data.google_project.project.id
+  project = data.google_project.project.project_id
 
   # the service URI we want to enable
   service = "container.googleapis.com"

--- a/terraform/03_gke_cluster.tf
+++ b/terraform/03_gke_cluster.tf
@@ -23,7 +23,7 @@ resource "random_shuffle" "zone" {
   # found that it only ever picked `us-central-1c` unless we seeded it. Here
   # we're using the ID of the project as a seed because it is unique to the
   # project but will not change, thereby guaranteeing stability of the results.
-  seed = data.google_project.project.id
+  seed = data.google_project.project.project_id
 }
 
 # First we create the cluster. If you're wondering where all the sizing details
@@ -40,7 +40,7 @@ resource "random_shuffle" "zone" {
 # replicates what the Hipster Shop README creates. If you want to see what else
 # is possible, check out the docs: https://www.terraform.io/docs/providers/google/r/container_cluster.html
 resource "google_container_cluster" "gke" {
-  project = data.google_project.project.id
+  project = data.google_project.project.project_id
 
   # Here's how you specify the name
   name = "stackdriver-sandbox"
@@ -113,7 +113,7 @@ resource "google_container_cluster" "gke" {
 # Set current project 
 resource "null_resource" "current_project" {
   provisioner "local-exec" {
-    command = "gcloud config set project ${data.google_project.project.id}"
+    command = "gcloud config set project ${data.google_project.project.project_id}"
   }
 }
 
@@ -128,7 +128,7 @@ resource "null_resource" "current_project" {
 # Setting kubectl context to currently deployed GKE cluster
 resource "null_resource" "set_gke_context" {
   provisioner "local-exec" {
-    command = "gcloud container clusters get-credentials stackdriver-sandbox --zone ${element(random_shuffle.zone.result, 0)} --project ${data.google_project.project.id}"
+    command = "gcloud container clusters get-credentials stackdriver-sandbox --zone ${element(random_shuffle.zone.result, 0)} --project ${data.google_project.project.project_id}"
   }
 
   depends_on = [


### PR DESCRIPTION
Changes data.google_project.project.id to data.google_project.project.project_id to prevent issues with setting the config through Terraform provider ~> 3.0.0