### PR TITLE
istio service SLO and alerting policies

### DIFF
--- a/terraform/install.sh
+++ b/terraform/install.sh
@@ -232,7 +232,7 @@ installMonitoring() {
   log "Creating monitoring examples (dashboards, uptime checks, alerting policies, etc.)..."
   pushd monitoring/
   terraform init -lock=false
-  terraform apply --auto-approve -var="project_id=${project_id}" -var="external_ip=${external_ip}" -var="project_owner_email=${acct}"
+  terraform apply --auto-approve -var="project_id=${project_id}" -var="external_ip=${external_ip}" -var="project_owner_email=${acct}" -var="zone=${CLUSTER_ZONE}"
   popd
 }
 

--- a/terraform/monitoring/03_services.tf
+++ b/terraform/monitoring/03_services.tf
@@ -87,7 +87,7 @@ resource "google_monitoring_custom_service" "custom_service" {
   display_name = var.custom_services[count.index].service_name
 }
 
-# Define services that will use the Istio service that is automatically detected
+# Specify services that will use the Istio service that is automatically detected
 # and created by installing Istio on the Kubernetes cluster.
 # The data members required are to successfully set up SLOs (goals and latency thresholds)
 # and burn rate limits for alerting policies

--- a/terraform/monitoring/03_services.tf
+++ b/terraform/monitoring/03_services.tf
@@ -86,3 +86,66 @@ resource "google_monitoring_custom_service" "custom_service" {
   service_id = "${var.custom_services[count.index].service_id}-srv"
   display_name = var.custom_services[count.index].service_name
 }
+
+# Define services that will use the Istio service that is automatically detected
+# and created by installing Istio on the Kubernetes cluster.
+# The data members required are to successfully set up SLOs (goals and latency thresholds)
+# and burn rate limits for alerting policies
+variable "istio_services" {
+  type = list(object({
+    service_name = string,
+    service_id = string,
+    availability_goal = number,
+    availability_burn_rate = number,
+    latency_goal = number,
+    latency_threshold = number,
+    latency_burn_rate = number
+  }))
+  default = [
+    {
+      service_name = "Cart Service"
+      service_id = "cartservice"
+      availability_goal = 0.99
+      availability_burn_rate = 2
+      latency_goal = 0.99
+      latency_threshold = 500
+      latency_burn_rate = 2
+    },
+    {
+      service_name = "Product Catalog Service"
+      service_id = "productcatalogservice"
+      availability_goal = 0.99
+      availability_burn_rate = 2
+      latency_goal = 0.99
+      latency_threshold = 500
+      latency_burn_rate = 2
+    },
+    {
+      service_name = "Currency Service"
+      service_id = "currencyservice"
+      availability_goal = 0.99
+      availability_burn_rate = 2
+      latency_goal = 0.99
+      latency_threshold = 500
+      latency_burn_rate = 2
+    },
+    {
+      service_name = "Recommendation Service"
+      service_id = "recommendationservice"
+      availability_goal = 0.99
+      availability_burn_rate = 2
+      latency_goal = 0.99
+      latency_threshold = 500
+      latency_burn_rate = 2
+    },
+    {
+      service_name = "Ad Service"
+      service_id = "adservice"
+      availability_goal = 0.99
+      availability_burn_rate = 2
+      latency_goal = 0.99
+      latency_threshold = 500
+      latency_burn_rate = 2
+    }
+  ]
+}

--- a/terraform/monitoring/04_slos.tf
+++ b/terraform/monitoring/04_slos.tf
@@ -88,3 +88,82 @@ resource "google_monitoring_slo" "custom_service_latency_slo" {
     }
   }
 }
+
+# Create an SLO for availablity for the Istio service.
+# Example SLO is defined as following:
+#   90% of all non-4XX requests within the past 30 day windowed period
+#   return with 200 OK status
+resource "google_monitoring_slo" "istio_service_availability_slo" {
+  count = length(var.istio_services)
+
+  # Uses the Istio service that is automatically detected and created by installing Istio
+  # Identify the service using the string: ist:${project_id}-zone-${zone}-cloud-ops-sandbox-default-${service_id}
+  service = "ist:${var.project_id}-zone-${var.zone}-cloud-ops-sandbox-default-${var.istio_services[count.index].service_id}"
+  slo_id = "availability-slo"
+  display_name = "Availability SLO with request base SLI (good total ratio)"
+
+  # The goal sets our objective for successful requests over the 30 day rolling window period
+  goal = var.istio_services[count.index].availability_goal
+  rolling_period_days = 30
+
+  request_based_sli {
+    good_total_ratio {
+
+      # The "good" service is the number of 200 OK responses
+      good_service_filter = join(" AND ", [
+        "metric.type=\"istio.io/service/server/request_count\"",
+        "resource.type=\"k8s_container\"",
+        "resource.label.\"cluster_name\"=\"cloud-ops-sandbox\"",
+        "metadata.user_labels.\"app\"=\"${var.istio_services[count.index].service_id}\"",
+        "metric.label.\"response_code\"=\"200\""
+      ])
+
+      # The total is the number of non-4XX responses
+      # We eliminate 4XX responses since they do not accurately represent server-side 
+      # failures and have the possibility of skewing our SLO measurements
+      total_service_filter = join(" AND ", [
+        "metric.type=\"istio.io/service/server/request_count\"",
+        "resource.type=\"k8s_container\"",
+        "resource.label.\"cluster_name\"=\"cloud-ops-sandbox\"",
+        "metadata.user_labels.\"app\"=\"${var.istio_services[count.index].service_id}\"",
+        join(" OR ", ["metric.label.\"response_code\"<\"400\"",
+          "metric.label.\"response_code\">=\"500\""])
+      ])
+      
+    }
+  }
+}
+
+# Create an SLO with respect to latency using the Istio service.
+# Example SLO is defined as:
+#   99% of requests that return 200 OK responses return in under 500 ms
+resource "google_monitoring_slo" "istio_service_latency_slo" {
+  count = length(var.istio_services)
+  service = "ist:${var.project_id}-zone-${var.zone}-cloud-ops-sandbox-default-${var.istio_services[count.index].service_id}"
+  slo_id = "latency-slo"
+  display_name = "Latency SLO with request base SLI (distribution cut)"
+
+  goal = var.istio_services[count.index].latency_goal
+  rolling_period_days = 30
+
+  request_based_sli {
+    distribution_cut {
+
+      # The distribution filter retrieves latencies of requests that returned 200 OK responses
+      distribution_filter = join(" AND ", [
+        "metric.type=\"istio.io/service/server/response_latencies\"",
+        "resource.type=\"k8s_container\"",
+        "resource.label.\"cluster_name\"=\"cloud-ops-sandbox\"",
+        "metric.label.\"response_code\"=\"200\"",
+        "metadata.user_labels.\"app\"=\"${var.istio_services[count.index].service_id}\""
+      ])
+
+      range {
+        # By not setting a min value, it is automatically set to -infinity
+        # The upper bound for latency is in ms
+        max = var.istio_services[count.index].latency_threshold
+
+      }
+    }
+  }
+}

--- a/terraform/monitoring/05_alerting_policies.tf
+++ b/terraform/monitoring/05_alerting_policies.tf
@@ -60,3 +60,49 @@ resource "google_monitoring_alert_policy" "custom_service_latency_slo_alert" {
     mime_type = "text/markdown"
   }
 }
+
+# Create an alerting policy on the Availability SLO for the Istio service.
+# The definition of the SLO can be found in the file '04_slos.tf'.
+# Alerts on error budget burn rate.
+resource "google_monitoring_alert_policy" "istio_service_availability_slo_alert" {
+  count = length(var.istio_services)
+  display_name = "${var.istio_services[count.index].service_name} Availability Alert Policy"
+  combiner     = "AND"
+  conditions {
+    display_name = "SLO burn rate alert for availability SLO with a threshold of ${var.istio_services[count.index].availability_burn_rate}"
+    condition_threshold {
+
+      # This filter alerts on burn rate over the past 60 minutes
+      # The service is defined by the unique Istio string that is automatically created
+      filter     = "select_slo_burn_rate(\"projects/${var.project_id}/services/ist:${var.project_id}-zone-${var.zone}-cloud-ops-sandbox-default-${var.istio_services[count.index].service_id}/serviceLevelObjectives/${google_monitoring_slo.istio_service_availability_slo[count.index].slo_id}\", 60m)"
+      threshold_value = "${var.istio_services[count.index].availability_burn_rate}"
+      comparison = "COMPARISON_GT"
+      duration   = "60s"
+    }
+  }
+  documentation {
+    content = "Availability SLO burn for the ${var.istio_services[count.index].service_name} for the past 60m exceeded ${var.istio_services[count.index].availability_burn_rate}x the acceptable budget burn rate. The service is returning less OK responses than desired. Consider viewing the service logs or custom dashboard to retrieve more information or adjust the values for the SLO and error budget."
+    mime_type = "text/markdown"
+  }
+}
+
+# Create another alerting policy, this time on the SLO for latency for the Istio service.
+# Alerts on error budget burn rate.
+resource "google_monitoring_alert_policy" "istio_service_latency_slo_alert" {
+  count = length(var.istio_services)
+  display_name = "${var.istio_services[count.index].service_name} Latency Alert Policy"
+  combiner     = "AND"
+  conditions {
+    display_name = "SLO burn rate alert for latency SLO with a threshold of ${var.istio_services[count.index].latency_burn_rate}"
+    condition_threshold {
+      filter     = "select_slo_burn_rate(\"projects/${var.project_id}/services/ist:${var.project_id}-zone-${var.zone}-cloud-ops-sandbox-default-${var.istio_services[count.index].service_id}/serviceLevelObjectives/${google_monitoring_slo.istio_service_latency_slo[count.index].slo_id}\", 60m)"
+      threshold_value = "${var.istio_services[count.index].availability_burn_rate}"
+      comparison = "COMPARISON_GT"
+      duration   = "60s"
+    }
+  }
+  documentation {
+    content = "Latency SLO burn for the ${var.istio_services[count.index].service_name} for the past 60m exceeded ${var.istio_services[count.index].latency_burn_rate}x the acceptable budget burn rate. The service is responding slower than desired. Consider viewing the service logs or custom dashboard to retrieve more information or adjust the values for the SLO and error budget."
+    mime_type = "text/markdown"
+  }
+}

--- a/terraform/monitoring/variables.tf
+++ b/terraform/monitoring/variables.tf
@@ -24,10 +24,15 @@ variable "external_ip" {
 
 variable "project_id" {
   type        = string
-  description = "The project id that was created by Stackdriver Sandbox. Can be revealed by running \"gcloud config get-value project\" in the Google Cloud CLI."
+  description = "The project id that was created by Cloud Operations Sandbox. Can be revealed by running \"gcloud config get-value project\" in the Google Cloud CLI."
 }
 
 variable "project_owner_email" {
 	type	      = string
 	description = "The email to receive alerts caused by violations of alerting policies."
+}
+
+variable "zone" {
+  type        = string
+  description = "The Zone of the Cloud Operations Sandbox cluster."
 }

--- a/tests/monitoring_integration_test.py
+++ b/tests/monitoring_integration_test.py
@@ -316,7 +316,6 @@ class TestSloAlertPolicy(unittest.TestCase):
 		found_latency_alert = self.checkForAlertingPolicy('Frontend Service Latency Alert Policy')
 		self.assertTrue(found_latency_alert)
 
-<<<<<<< HEAD
 	def testCheckoutServiceSloAlertExists(self):
 		""" Test that the Alerting Policies for the Checkout Service SLO get created. """
 		found_availability_alert = self.checkForAlertingPolicy('Checkout Service Availability Alert Policy')
@@ -343,7 +342,8 @@ class TestSloAlertPolicy(unittest.TestCase):
 		found_availability_alert = self.checkForAlertingPolicy('Shipping Service Availability Alert Policy')
 		self.assertTrue(found_availability_alert)
 		found_latency_alert = self.checkForAlertingPolicy('Shipping Service Latency Alert Policy')
-=======
+		self.assertTrue(found_latency_alert)
+
 	def testCartServiceSloAlertExists(self):
 		""" Test that the Alerting Policies for the Cart Service SLO get created. """
 		found_availability_alert = self.checkForAlertingPolicy('Cart Service Availability Alert Policy')
@@ -377,7 +377,6 @@ class TestSloAlertPolicy(unittest.TestCase):
 		found_availability_alert = self.checkForAlertingPolicy('Ad Service Availability Alert Policy')
 		self.assertTrue(found_availability_alert)
 		found_latency_alert = self.checkForAlertingPolicy('Ad Service Latency Alert Policy')
->>>>>>> 2a51b1b... rebased
 		self.assertTrue(found_latency_alert)
 
 if __name__ == '__main__':


### PR DESCRIPTION
#WHAT: SLOs and alerting policies for 5 of the microservices using the automatically created Istio services.

#WHY: All services should have SLOs and alerting policies. Here we demonstrate how to use the Istio services for these monitoring examples.

#HOW: Terraform resources for each SLO and alerting policy
- Uses the Istio string for service identification that is automatically created by installing Istio

#TESTING: Tests added for all resources. Currently passing, will merge once tests go into CI.

Closes #71, #72, #73, #78, #79