### PR TITLE
Documentation for OpenTelemetry Instrumentation

### DIFF
--- a/src/checkoutservice/main.go
+++ b/src/checkoutservice/main.go
@@ -121,6 +121,7 @@ func main() {
 	}
 	srv := grpc.NewServer(
 		grpc.StatsHandler(&ocgrpc.ServerHandler{}), // TODO: replace with OTel grpc metrics collector
+		// OpenTelemetry gRPC server channel interceptors receive trace contexts from clients.
 		grpc.UnaryInterceptor(grpctrace.UnaryServerInterceptor(global.TraceProvider().Tracer("checkout"))),
 		grpc.StreamInterceptor(grpctrace.StreamServerInterceptor(global.TraceProvider().Tracer("checkout"))),
 	)
@@ -158,6 +159,12 @@ func initOpenCensusStats() {
 
 // Initialize OTel trace provider that exports to Cloud Trace
 func initTraceProvider() {
+	// When running on GCP, authentication is handled automatically
+	// using default credentials. This environment variable check
+	// is to help debug projects running locally. It's possible for this
+	// warning to be printed while the exporter works normally. See
+	// https://developers.google.com/identity/protocols/application-default-credentials
+	// for more details.
 	projectID := os.Getenv("GOOGLE_CLOUD_PROJECT")
 	if len(projectID) == 0 {
 		log.Warn("GOOGLE_CLOUD_PROJECT not set")
@@ -168,8 +175,9 @@ func initTraceProvider() {
 			log.Infof("failed to initialize exporter: %v", err)
 		} else {
 			// Create trace provider with the exporter.
-			// The AlwaysSample sampling policy is used here for demonstration
-			// purposes and should not be used in production environments.
+			// This is a demo app with low QPS. AlwaysSample() is used here
+			// to make sure traces are available for observation and analysis.
+			// It should not be used in production environments.
 			tp, err := sdktrace.NewProvider(sdktrace.WithConfig(
 				sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}),
 				sdktrace.WithSyncer(exporter),
@@ -412,6 +420,7 @@ func mustConnGRPC(ctx context.Context, conn **grpc.ClientConn, addr string) {
 		grpc.WithInsecure(),
 		grpc.WithTimeout(time.Second*3),
 		grpc.WithStatsHandler(&ocgrpc.ClientHandler{}), // TODO: replace with OTel grpc metrics collector
+		// OpenTelemetry gRPC client channel interceptors pass trace contexts to the server.
 		grpc.WithUnaryInterceptor(grpctrace.UnaryClientInterceptor(global.TraceProvider().Tracer("checkout"))),
 		grpc.WithStreamInterceptor(grpctrace.StreamClientInterceptor(global.TraceProvider().Tracer("checkout"))))
 	if err != nil {

--- a/src/currencyservice/server.js
+++ b/src/currencyservice/server.js
@@ -34,7 +34,7 @@ const {TraceExporter} = require('@google-cloud/opentelemetry-cloud-trace-exporte
 
 // OpenTelemetry tracing with exporter to Google Cloud Trace
 const provider = new NodeTracerProvider({
-  // Use grpc plugin to receive trace contexts from client
+  // Use grpc plugin to receive trace contexts from clients.
   plugins: {
     grpc: {
       enabled: true,
@@ -42,7 +42,12 @@ const provider = new NodeTracerProvider({
     }
   }
 });
-// Cloud Trace Exporter handles credentials.
+
+// Enable OpenTelemetry exporters to export traces to Google Cloud Trace.
+// Exporters use Application Default Credentials (ADCs) to authenticate.
+// See https://developers.google.com/identity/protocols/application-default-credentials
+// for more details. When your application is running on GCP,
+// you don't need to provide auth credentials or a project id.
 const exporter = new TraceExporter();
 provider.addSpanProcessor(new BatchSpanProcessor(exporter));
 provider.register();
@@ -136,10 +141,12 @@ function _carry (amount) {
  * Lists the supported currencies
  */
 function getSupportedCurrencies (call, callback) {
+  // Extract the span context received from the gRPC client.
+  // Create a child span and add an event.
   const currentSpan = tracer.getCurrentSpan();
   const span = tracer.startSpan('currencyservice:GetSupportedCurrencies()', {
     parent: currentSpan,
-    kind: 1, //server
+    kind: 1, // server
   });
   span.addEvent('Get Supported Currencies');
   logger.info('Getting supported currencies...');
@@ -153,10 +160,12 @@ function getSupportedCurrencies (call, callback) {
  * Converts between currencies
  */
 function convert (call, callback) {
+  // Extract the span context received from the gRPC client.
+  // Create a child span and add an event.
   const currentSpan = tracer.getCurrentSpan();
   const span = tracer.startSpan('currencyservice:Convert()', {
     parent: currentSpan,
-    kind: 1, //server
+    kind: 1, // server
   });
   logger.info('received conversion request');
   try {
@@ -214,4 +223,5 @@ function main () {
 }
 
 main();
+// Flush all traces and shut down the Cloud Trace exporter.
 exporter.shutdown();

--- a/src/paymentservice/tracer.js
+++ b/src/paymentservice/tracer.js
@@ -12,15 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Initialize OpenTelemetry tracing for the payment service.
+// This tracer is needed in both server.js and index.js
 const opentelemetry = require('@opentelemetry/api');
 const {NodeTracerProvider} = require('@opentelemetry/node');
 const {BatchSpanProcessor} = require('@opentelemetry/tracing');
+
+// Enable OpenTelemetry exporters to export traces to Google Cloud Trace.
+// Exporters use Application Default Credentials (ADCs) to authenticate.
+// See https://developers.google.com/identity/protocols/application-default-credentials
+// for more details. When your application is running on GCP,
+// you don't need to provide auth credentials or a project id.
 const {TraceExporter} = require('@google-cloud/opentelemetry-cloud-trace-exporter');
 
 module.exports = () => {
-    // OpenTelemetry tracing with exporter to Google Cloud Trace
     const provider = new NodeTracerProvider({
-        // Use grpc plugin to receive trace contexts from client
+        // Use grpc plugin to receive trace contexts from client (checkout)
         plugins: {
             grpc: {
                 enabled: true,
@@ -28,7 +35,6 @@ module.exports = () => {
             }
         }
     });
-    // Cloud Trace Exporter handles credentials.
     provider.addSpanProcessor(new BatchSpanProcessor(new TraceExporter()));
 
     // Initialize the OpenTelemetry APIs to use the NodeTracerProvider bindings

--- a/src/productcatalogservice/server.go
+++ b/src/productcatalogservice/server.go
@@ -130,7 +130,8 @@ func run(port int) string {
 		log.Fatal(err)
 	}
 	srv := grpc.NewServer(
-		grpc.StatsHandler(&ocgrpc.ServerHandler{}),
+		grpc.StatsHandler(&ocgrpc.ServerHandler{}), // TODO: replace with OTel grpc metrics collector
+		// OpenTelemetry gRPC server channel interceptors receive trace contexts from clients.
 		grpc.UnaryInterceptor(grpctrace.UnaryServerInterceptor(global.TraceProvider().Tracer("productcatalog"))),
 		grpc.StreamInterceptor(grpctrace.StreamServerInterceptor(global.TraceProvider().Tracer("productcatalog"))),
 	)
@@ -171,7 +172,12 @@ func initOpenCensusStats() {
 
 // Initialize OTel trace provider that exports to Cloud Trace
 func initTraceProvider() {
-	// Initialize exporter OTel Trace -> Google Cloud Trace
+	// When running on GCP, authentication is handled automatically
+	// using default credentials. This environment variable check
+	// is to help debug projects running locally. It's possible for this
+	// warning to be printed while the exporter works normally. See
+	// https://developers.google.com/identity/protocols/application-default-credentials
+	// for more details.
 	projectID := os.Getenv("GOOGLE_CLOUD_PROJECT")
 	if len(projectID) == 0 {
 		log.Warn("GOOGLE_CLOUD_PROJECT not set")

--- a/src/shippingservice/main.go
+++ b/src/shippingservice/main.go
@@ -174,6 +174,12 @@ func initOpenCensusStats() {
 
 // Initialize OTel trace provider that exports to Cloud Trace
 func initTraceProvider() {
+	// When running on GCP, authentication is handled automatically
+	// using default credentials. This environment variable check
+	// is to help debug projects running locally. It's possible for this
+	// warning to be printed while the exporter works normally. See
+	// https://developers.google.com/identity/protocols/application-default-credentials
+	// for more details.
 	projectID := os.Getenv("GOOGLE_CLOUD_PROJECT")
 	if len(projectID) == 0 {
 		log.Warn("GOOGLE_CLOUD_PROJECT not set")


### PR DESCRIPTION
Adds thorough and consistent documentation about the OpenTelemetry tracing instrumentation to each service. A few key points:
- How authentication is handled in the cloud trace exporters.
- Warnings for PROJECT_ID when the environment variable isn't found, but also noting that this is not needed when running on GCP.
- Reminders when certain implementations would not be appropriate for production environments (i.e. AlwaysSample)
- Distinguishing between "client" and "server" responsibilities within the services
- And other miscellaneous things!

Also, there was an OpenCensus tracer leftover in frontend - I removed it and tested to make sure it doesn't affect the dashboards.

Part of #132 - we're close to the end!