### PR TITLE
rebranding for monitoring terraform

### DIFF
--- a/terraform/monitoring/03_service_slo.tf
+++ b/terraform/monitoring/03_service_slo.tf
@@ -46,7 +46,7 @@ resource "google_monitoring_slo" "frontend_availability_slo" {
       good_service_filter = join(" AND ", [
         "metric.type=\"istio.io/service/server/request_count\"",
         "resource.type=\"k8s_container\"",
-        "resource.label.\"cluster_name\"=\"stackdriver-sandbox\"",
+        "resource.label.\"cluster_name\"=\"cloud-ops-sandbox\"",
         "metadata.user_labels.\"app\"=\"frontend\"",
         "metric.label.\"response_code\"=\"200\""
       ])
@@ -57,7 +57,7 @@ resource "google_monitoring_slo" "frontend_availability_slo" {
       total_service_filter = join(" AND ", [
         "metric.type=\"istio.io/service/server/request_count\"",
         "resource.type=\"k8s_container\"",
-        "resource.label.\"cluster_name\"=\"stackdriver-sandbox\"",
+        "resource.label.\"cluster_name\"=\"cloud-ops-sandbox\"",
         "metadata.user_labels.\"app\"=\"frontend\"",
         join(" OR ", ["metric.label.\"response_code\"<\"400\"",
           "metric.label.\"response_code\">=\"500\""])
@@ -86,7 +86,7 @@ resource "google_monitoring_slo" "frontend_latency_slo" {
       distribution_filter = join(" AND ", [
         "metric.type=\"istio.io/service/server/response_latencies\"",
         "resource.type=\"k8s_container\"",
-        "resource.label.\"cluster_name\"=\"stackdriver-sandbox\"",
+        "resource.label.\"cluster_name\"=\"cloud-ops-sandbox\"",
         "metric.label.\"response_code\"=\"200\"",
         "metadata.user_labels.\"app\"=\"frontend\""
       ])

--- a/terraform/monitoring/README.md
+++ b/terraform/monitoring/README.md
@@ -4,7 +4,7 @@ Hipster Shop Monitoring Terraform
 ## This directory is currently under construction.
 
 This directory contains documented [Terraform] for provisioning monitoring examples
-for the microservices contained in the demo application provisioned by Stackdriver Sandbox.
+for the microservices contained in the demo application provisioned by Cloud Operations Sandbox.
 
 Please note that in order to provision these monitoring examples a [Monitoring Workspace] 
 must be associated with your project.

--- a/terraform/monitoring/dashboards/adservice_dashboard.json
+++ b/terraform/monitoring/dashboards/adservice_dashboard.json
@@ -10,7 +10,7 @@
             {
               "timeSeriesQuery": {
                 "timeSeriesFilter": {
-                  "filter": "metric.type=\"kubernetes.io/container/cpu/limit_utilization\" resource.type=\"k8s_container\" resource.label.\"cluster_name\"=\"stackdriver-sandbox\" metadata.user_labels.\"app\"=\"adservice\" resource.label.\"container_name\"=\"server\"",
+                  "filter": "metric.type=\"kubernetes.io/container/cpu/limit_utilization\" resource.type=\"k8s_container\" resource.label.\"cluster_name\"=\"cloud-ops-sandbox\" metadata.user_labels.\"app\"=\"adservice\" resource.label.\"container_name\"=\"server\"",
                   "aggregation": {
                     "perSeriesAligner": "ALIGN_MEAN"
                   }
@@ -37,7 +37,7 @@
             {
               "timeSeriesQuery": {
                 "timeSeriesFilter": {
-                  "filter": "metric.type=\"istio.io/service/server/request_count\" resource.type=\"k8s_container\" resource.label.\"cluster_name\"=\"stackdriver-sandbox\" metadata.user_labels.\"app\"=\"adservice\"",
+                  "filter": "metric.type=\"istio.io/service/server/request_count\" resource.type=\"k8s_container\" resource.label.\"cluster_name\"=\"cloud-ops-sandbox\" metadata.user_labels.\"app\"=\"adservice\"",
                   "aggregation": {
                     "perSeriesAligner": "ALIGN_RATE"
                   }
@@ -118,7 +118,7 @@
             {
               "timeSeriesQuery": {
                 "timeSeriesFilter": {
-                  "filter": "metric.type=\"istio.io/service/server/response_latencies\" resource.type=\"k8s_container\" resource.label.\"cluster_name\"=\"stackdriver-sandbox\" metadata.user_labels.\"app\"=\"adservice\"",
+                  "filter": "metric.type=\"istio.io/service/server/response_latencies\" resource.type=\"k8s_container\" resource.label.\"cluster_name\"=\"cloud-ops-sandbox\" metadata.user_labels.\"app\"=\"adservice\"",
                   "aggregation": {
                     "perSeriesAligner": "ALIGN_PERCENTILE_99"
                   }

--- a/terraform/monitoring/dashboards/frontend_dashboard.json
+++ b/terraform/monitoring/dashboards/frontend_dashboard.json
@@ -10,7 +10,7 @@
             {
               "timeSeriesQuery": {
                 "timeSeriesFilter": {
-                  "filter": "metric.type=\"kubernetes.io/container/cpu/limit_utilization\" resource.type=\"k8s_container\" resource.label.\"cluster_name\"=\"stackdriver-sandbox\" metadata.user_labels.\"app\"=\"frontend\"",
+                  "filter": "metric.type=\"kubernetes.io/container/cpu/limit_utilization\" resource.type=\"k8s_container\" resource.label.\"cluster_name\"=\"cloud-ops-sandbox\" metadata.user_labels.\"app\"=\"frontend\"",
                   "aggregation": {
                     "perSeriesAligner": "ALIGN_MEAN"
                   }
@@ -37,7 +37,7 @@
             {
               "timeSeriesQuery": {
                 "timeSeriesFilter": {
-                  "filter": "metric.type=\"istio.io/service/server/request_count\" resource.type=\"k8s_container\" resource.label.\"cluster_name\"=\"stackdriver-sandbox\" metadata.user_labels.\"app\"=\"frontend\"",
+                  "filter": "metric.type=\"istio.io/service/server/request_count\" resource.type=\"k8s_container\" resource.label.\"cluster_name\"=\"cloud-ops-sandbox\" metadata.user_labels.\"app\"=\"frontend\"",
                   "aggregation": {
                     "perSeriesAligner": "ALIGN_RATE"
                   }
@@ -64,7 +64,7 @@
             {
               "timeSeriesQuery": {
                 "timeSeriesFilter": {
-                  "filter": "metric.type=\"istio.io/service/server/request_count\" resource.type=\"k8s_container\" resource.label.\"cluster_name\"=\"stackdriver-sandbox\" metadata.user_labels.\"app\"=\"frontend\" metric.label.\"response_code\"!=\"200\"",
+                  "filter": "metric.type=\"istio.io/service/server/request_count\" resource.type=\"k8s_container\" resource.label.\"cluster_name\"=\"cloud-ops-sandbox\" metadata.user_labels.\"app\"=\"frontend\" metric.label.\"response_code\"!=\"200\"",
                   "aggregation": {
                     "perSeriesAligner": "ALIGN_RATE"
                   }
@@ -91,7 +91,7 @@
             {
               "timeSeriesQuery": {
                 "timeSeriesFilter": {
-                  "filter": "metric.type=\"istio.io/service/server/response_latencies\" resource.type=\"k8s_container\" resource.label.\"cluster_name\"=\"stackdriver-sandbox\" metadata.user_labels.\"app\"=\"frontend\"",
+                  "filter": "metric.type=\"istio.io/service/server/response_latencies\" resource.type=\"k8s_container\" resource.label.\"cluster_name\"=\"cloud-ops-sandbox\" metadata.user_labels.\"app\"=\"frontend\"",
                   "aggregation": {
                     "perSeriesAligner": "ALIGN_PERCENTILE_99"
                   }

--- a/terraform/monitoring/dashboards/generic_dashboard.tmpl
+++ b/terraform/monitoring/dashboards/generic_dashboard.tmpl
@@ -10,7 +10,7 @@
             {
               "timeSeriesQuery": {
                 "timeSeriesFilter": {
-                  "filter": "metric.type=\"kubernetes.io/container/cpu/limit_utilization\" resource.type=\"k8s_container\" resource.label.\"cluster_name\"=\"stackdriver-sandbox\" metadata.user_labels.\"app\"=\"${service_id}\"",
+                  "filter": "metric.type=\"kubernetes.io/container/cpu/limit_utilization\" resource.type=\"k8s_container\" resource.label.\"cluster_name\"=\"cloud-ops-sandbox\" metadata.user_labels.\"app\"=\"${service_id}\"",
                   "aggregation": {
                     "perSeriesAligner": "ALIGN_MEAN"
                   }
@@ -37,7 +37,7 @@
             {
               "timeSeriesQuery": {
                 "timeSeriesFilter": {
-                  "filter": "metric.type=\"istio.io/service/server/request_count\" resource.type=\"k8s_container\" resource.label.\"cluster_name\"=\"stackdriver-sandbox\" metadata.user_labels.\"app\"=\"${service_id}\"",
+                  "filter": "metric.type=\"istio.io/service/server/request_count\" resource.type=\"k8s_container\" resource.label.\"cluster_name\"=\"cloud-ops-sandbox\" metadata.user_labels.\"app\"=\"${service_id}\"",
                   "aggregation": {
                     "perSeriesAligner": "ALIGN_RATE"
                   }
@@ -64,7 +64,7 @@
             {
               "timeSeriesQuery": {
                 "timeSeriesFilter": {
-                  "filter": "metric.type=\"istio.io/service/server/request_count\" resource.type=\"k8s_container\" resource.label.\"cluster_name\"=\"stackdriver-sandbox\" metadata.user_labels.\"app\"=\"${service_id}\" metric.label.\"response_code\"!=\"200\"",
+                  "filter": "metric.type=\"istio.io/service/server/request_count\" resource.type=\"k8s_container\" resource.label.\"cluster_name\"=\"cloud-ops-sandbox\" metadata.user_labels.\"app\"=\"${service_id}\" metric.label.\"response_code\"!=\"200\"",
                   "aggregation": {
                     "perSeriesAligner": "ALIGN_RATE"
                   }
@@ -91,7 +91,7 @@
             {
               "timeSeriesQuery": {
                 "timeSeriesFilter": {
-                  "filter": "metric.type=\"istio.io/service/server/response_latencies\" resource.type=\"k8s_container\" resource.label.\"cluster_name\"=\"stackdriver-sandbox\" metadata.user_labels.\"app\"=\"${service_id}\"",
+                  "filter": "metric.type=\"istio.io/service/server/response_latencies\" resource.type=\"k8s_container\" resource.label.\"cluster_name\"=\"cloud-ops-sandbox\" metadata.user_labels.\"app\"=\"${service_id}\"",
                   "aggregation": {
                     "perSeriesAligner": "ALIGN_PERCENTILE_99"
                   }

--- a/terraform/monitoring/dashboards/recommendationservice_dashboard.json
+++ b/terraform/monitoring/dashboards/recommendationservice_dashboard.json
@@ -10,7 +10,7 @@
             {
               "timeSeriesQuery": {
                 "timeSeriesFilter": {
-                  "filter": "metric.type=\"kubernetes.io/container/cpu/limit_utilization\" resource.type=\"k8s_container\" resource.label.\"cluster_name\"=\"stackdriver-sandbox\" metadata.user_labels.\"app\"=\"recommendationservice\" resource.label.\"container_name\"=\"server\"",
+                  "filter": "metric.type=\"kubernetes.io/container/cpu/limit_utilization\" resource.type=\"k8s_container\" resource.label.\"cluster_name\"=\"cloud-ops-sandbox\" metadata.user_labels.\"app\"=\"recommendationservice\" resource.label.\"container_name\"=\"server\"",
                   "aggregation": {
                     "perSeriesAligner": "ALIGN_MEAN"
                   }
@@ -37,7 +37,7 @@
             {
               "timeSeriesQuery": {
                 "timeSeriesFilter": {
-                  "filter": "metric.type=\"istio.io/service/server/request_count\" resource.type=\"k8s_container\" resource.label.\"cluster_name\"=\"stackdriver-sandbox\" metadata.user_labels.\"app\"=\"recommendationservice\"",
+                  "filter": "metric.type=\"istio.io/service/server/request_count\" resource.type=\"k8s_container\" resource.label.\"cluster_name\"=\"cloud-ops-sandbox\" metadata.user_labels.\"app\"=\"recommendationservice\"",
                   "aggregation": {
                     "perSeriesAligner": "ALIGN_RATE"
                   }
@@ -118,7 +118,7 @@
             {
               "timeSeriesQuery": {
                 "timeSeriesFilter": {
-                  "filter": "metric.type=\"istio.io/service/server/response_latencies\" resource.type=\"k8s_container\" resource.label.\"cluster_name\"=\"stackdriver-sandbox\" metadata.user_labels.\"app\"=\"recommendationservice\"",
+                  "filter": "metric.type=\"istio.io/service/server/response_latencies\" resource.type=\"k8s_container\" resource.label.\"cluster_name\"=\"cloud-ops-sandbox\" metadata.user_labels.\"app\"=\"recommendationservice\"",
                   "aggregation": {
                     "perSeriesAligner": "ALIGN_PERCENTILE_99"
                   }


### PR DESCRIPTION
Renames the cluster to cloud-ops-sandbox as a subtask of #334 

Needs to be merged after #337 
