### PR TITLE
Updated root documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 
-# Stackdriver Sandbox (Alpha)
+# Cloud Operations Sandbox (Alpha)
 
 ![Continuous Integration](https://github.com/GoogleCloudPlatform/stackdriver-sandbox/workflows/Continuous%20Integration/badge.svg)
 
-Stackdriver Sandbox is an open-source tool that helps practitioners to learn Service Reliability Engineering practices from Google and apply them on their cloud services using [Ops Management](https://cloud.google.com/products/operations) (formerly Stackdriver).
+Cloud Operations Sandbox is an open-source tool that helps practitioners to learn Service Reliability Engineering practices from Google and apply them on their cloud services using [Ops Management](https://cloud.google.com/products/operations) (formerly Stackdriver).
 It is based on [Hipster Shop](https://github.com/GoogleCloudPlatform/microservices-demo), a cloud-native microservices application.
 
 Sandbox offers:
@@ -39,11 +39,11 @@ With Sandbox, we provide a tool that automatically provisions a new demo cluster
 
 ### Set Up
 
-1. Click the Cloud Shell button for automated one-click installation of a new Stackdriver Sandbox cluster in a new Google Cloud Project.
+1. Click the Cloud Shell button for automated one-click installation of a new Sandbox cluster in a new Google Cloud Project.
 
-[![Open in Cloud Shell](http://www.gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/stackdriver-sandbox.git&cloudshell_git_branch=master&cloudshell_working_dir=terraform&cloudshell_image=gcr.io/cloudshell-images/cloudshell)
+[![Open in Cloud Shell](http://www.gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/stackdriver-sandbox.git&cloudshell_git_branch=master&cloudshell_working_dir=terraform&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image:v0.2.0")
 
-1. In the Cloud Shell command prompt, type:
+__Note__: If installation stops due to billing account errors, set up the billing account, and then in the Cloud Shell command prompt, type:
 
 ```bash
 ./install.sh
@@ -57,15 +57,15 @@ With Sandbox, we provide a tool that automatically provisions a new demo cluster
 
 ### Clean Up
 
-When you are done using Stackdriver Sandbox, you can tear down the environment by deleting the GCP project that was set up for you. This can be accomplished in any of the following ways:
+When you are done using Cloud Operations Sandbox, you can tear down the environment by deleting the GCP project that was set up for you. This can be accomplished in any of the following ways:
 
-* Use the Stackdriver Sandbox `destroy` script:
+* Use the Sandbox `destroy` script:
 
 ```bash
 ./destroy.sh
 ```
 
-* If you no longer have the Stackdriver Sandbox files downloaded, delete your project manually using `gcloud`
+* If you no longer have the Cloud Operations Sandbox files downloaded, delete your project manually using `gcloud`
 
 ```bash
 gcloud projects delete $YOUR_PROJECT_ID

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ With Sandbox, we provide a tool that automatically provisions a new demo cluster
 
 1. Click the Cloud Shell button for automated one-click installation of a new Sandbox cluster in a new Google Cloud Project.
 
-[![Open in Cloud Shell](http://www.gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/stackdriver-sandbox.git&cloudshell_git_branch=master&cloudshell_working_dir=terraform&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image:v0.2.0")
+[![Open in Cloud Shell](http://www.gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/stackdriver-sandbox.git&cloudshell_git_branch=v0.2.0&cloudshell_working_dir=terraform&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image:v0.2.0)
 
 __Note__: If installation stops due to billing account errors, set up the billing account, and then in the Cloud Shell command prompt, type:
 

--- a/README.md
+++ b/README.md
@@ -39,15 +39,11 @@ With Sandbox, we provide a tool that automatically provisions a new demo cluster
 
 ### Set Up
 
-1. Click the Cloud Shell button for automated one-click installation of a new Sandbox cluster in a new Google Cloud Project.
+Click the Cloud Shell button for automated one-click installation of a new Sandbox cluster in a new Google Cloud Project.
 
 [![Open in Cloud Shell](http://www.gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/stackdriver-sandbox.git&cloudshell_git_branch=v0.2.0&cloudshell_working_dir=terraform&shellonly=true&cloudshell_image=gcr.io/stackdriver-sandbox-230822/cloudshell-image:v0.2.0)
 
-__Note__: If installation stops due to billing account errors, set up the billing account, and then in the Cloud Shell command prompt, type:
-
-```bash
-./install.sh
-```
+__Note__: If installation stops due to billing account errors, set up the billing account, and then in the `terraform/` diretory of the project created in Cloud Shell command prompt, type: `./install.sh`.
 
 ### Next Steps
 


### PR DESCRIPTION
The root `README.md` file has been updated with the following changes:
- Adds custom cloud shell image URL to "Open in Cloud Shell" button
- "Open in Cloud Shell" button points at `v0.2.0` branch instead of `master`
- Updates instructions for running `install.sh` with custom cloud shell image
- "Stackdriver Sandbox" is re-branded to "Cloud Operations Sandbox" in some places; shortened to "Sandbox" in others

One potential issue this raises is that every time a new release occurs, not only will the "Open in Cloud Shell" button on the website have to be updated to point at `vx.x.x`, but the "Open in Cloud Shell" button in the root directory must be updated to point at new version as well, which could easily be missed.

Some potential solutions could be:
- redirecting users to website page from the root documentation
- creating a more robust "version update checklist" for developers on Sandbox which includes updating root `README.md` documentation